### PR TITLE
Fixed the error 'missing initializer' in struct option longopts (xside.c)

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -2611,7 +2611,7 @@ struct option longopts[] = {
 	{ "title-name", no_argument, NULL, 'T' },
 	{ "trayicon-mode", required_argument, NULL, opt_trayicon_mode },
 	{ "help", no_argument, NULL, 'h' },
-	{ },
+	{ 0, 0, 0, 0 },
 };
 static const char optstring[] = "d:t:N:c:l:i:K:vqQnafIp:Th";
 


### PR DESCRIPTION
When building the new main branch, there's error because the last null entry in **struct option longopts**  is not properly initialized.

```
make[1]: Entering directory `/home/user/qubes-src/gui-daemon/gui-daemon'
gcc -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC `pkg-config --cflags libconfig` `pkg-config --cflags libnotify` `pkg-config --cflags libpng` `pkg-config --cflags vchan-xen`   -c -o xside.o xside.c
xside.c:2614:2: error: missing initializer for field 'name' of 'struct option' [-Werror=missing-field-initializers]
  { },
  ^
In file included from xside.c:40:0:
/usr/include/getopt.h:106:15: note: 'name' declared here
   const char *name;
               ^
cc1: all warnings being treated as errors
make[1]: *** [xside.o] Error 1
make[1]: Leaving directory `/home/user/qubes-src/gui-daemon/gui-daemon'
make: *** [gui-daemon/qubes-guid] Error 2
```

Signed-off-by: WetwareLabs <marcus@wetwa.re>