### PR TITLE
Move /var/run/shm.id to /var/run/qubes/shm.id

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -3184,10 +3184,11 @@ int main(int argc, char **argv)
 
 	// inside the daemonized process...
 	if (!ghandles.invisible) {
-		f = fopen("/var/run/shm.id", "r");
+		f = fopen(GUID_SHMID_FILE, "r");
 		if (!f) {
 			fprintf(stderr,
-					"Missing /var/run/shm.id; run X with preloaded shmoverride\n");
+					"Missing %s; run X with preloaded shmoverride\n",
+					GUID_SHMID_FILE);
 			exit(1);
 		}
 		fscanf(f, "%d", &ghandles.cmd_shmid);
@@ -3195,8 +3196,9 @@ int main(int argc, char **argv)
 		ghandles.shmcmd = shmat(ghandles.cmd_shmid, NULL, 0);
 		if (ghandles.shmcmd == (void *) (-1UL)) {
 			fprintf(stderr,
-					"Invalid or stale shm id 0x%x in /var/run/shm.id\n",
-					ghandles.cmd_shmid);
+					"Invalid or stale shm id 0x%x in %s\n",
+					ghandles.cmd_shmid,
+					GUID_SHMID_FILE);
 			exit(1);
 		}
 	}

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -30,6 +30,7 @@
 #define QREXEC_POLICY_PATH "/usr/lib/qubes/qrexec-policy"
 #define GUID_CONFIG_FILE "/etc/qubes/guid.conf"
 #define GUID_CONFIG_DIR "/etc/qubes"
+#define GUID_SHMID_FILE "/var/run/qubes/shm.id"
 /* this makes any X11 error fatal (i.e. cause exit(1)). This behavior was the
  * case for a long time before introducing this option, so nothing really have
  * changed  */

--- a/shmoverride/README
+++ b/shmoverride/README
@@ -5,7 +5,7 @@ instead of attaching regular shared memory, memory from a foreign domain is
 attached via xc_map_foreign_pages. This mechanism is used to map composition
 buffers from a foreign domain into Xorg server.
 	During its init, shmoverride.so creates a shared memory segment
-(cmd_pages) and writes its shmid to /var/run/shm.id. All instances of
+(cmd_pages) and writes its shmid to /var/run/qubes/shm.id. All instances of
 qubes_guid map this segment and communicate with shmoverride.so code by
 setting its fields. When qubes_guid wants its
 XShmAttach(...synth_shmid...) call to be handled by shmoverride.so, it sets the 

--- a/shmoverride/shmoverride.c
+++ b/shmoverride/shmoverride.c
@@ -114,7 +114,7 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
     return 0;
 }
 
-#define SHMID_FILENAME "/var/run/shm.id"
+#define SHMID_FILENAME "/var/run/qubes/shm.id"
 int __attribute__ ((constructor)) initfunc()
 {
     int idfd, len;


### PR DESCRIPTION
This allows the gui daemon to be run without root privileges.
