### PR TITLE
Fix sending monitor layout info when xrandr has one output disconnected

### DIFF
--- a/screen-layout-handler/monitorlayoutnotify.py
+++ b/screen-layout-handler/monitorlayoutnotify.py
@@ -32,7 +32,8 @@ REGEX_OUTPUT = re.compile(r"""
         (?x)                           # ignore whitespace
         ^                              # start of string
         (?P<output>[A-Za-z0-9\-]*)[ ]  # LVDS VGA etc
-        (?P<connect>(dis)?connected)[ ]# dis/connected
+        (?P<connect>(dis)?connected)   # dis/connected
+        ([ ]   
         (?P<primary>(primary)?)[ ]?
         ((                             # a group
            (?P<width>\d+)x             # either 1024x768+0+0
@@ -46,6 +47,7 @@ REGEX_OUTPUT = re.compile(r"""
            (?P<height_mm>\d+)mm
         )?
         .*                             # ignore rest of line
+        )?                             # everything after (dis)connect is optional
         """)
 
 def get_monitor_layout():


### PR DESCRIPTION
When one output is disconnected, parsing "xrandr -q" will fail (for example line "VGA-0 disconnected"). This causes error message "Error starting VM <vm>: 'NoneType' object has no attribute 'groupdict'." when launching a VM.

The actual culprit is the required space after "(dis?)connected", but making everything after that optional solves the problem. Can be tested with following xrandr output:
```
Screen 0: minimum 320 x 200, current 3840 x 1200, maximum 16384 x 16384
HDMI-0 connected primary 1920x1200+0+0 518mm x 324mm
   1920x1200     59.95*+
   1920x1080     60.00
   1600x1200     60.00
   1680x1050     59.88
   1280x1024     60.02
   1440x900      59.90
   1280x800      59.91
   1280x720      60.00
   1024x768      60.00
   800x600       60.32
   640x480       60.00
   720x400       70.08
DVI-0 connected 1920x1080+1920+0 477mm x 268mm
   1920x1080     60.00*+
   1680x1050     59.88
   1600x900      60.00
   1280x1024     75.02    60.02
   1280x960      60.00
   1152x864      75.00
   1280x720      60.00
   1152x720      59.97
   1024x768      75.08    60.00
   832x624       74.55
   800x600       75.00    60.32
   640x480       75.00    60.00
   720x400       70.08
VGA-0 disconnected
```
 

Signed-off-by: WetwareLabs <marcus@wetwa.re>