### PR TITLE
Allow copying out of dom0 at qrexec-policy level

### DIFF
--- a/gui-daemon/qubes.ClipboardPaste.policy
+++ b/gui-daemon/qubes.ClipboardPaste.policy
@@ -6,5 +6,6 @@
 
 ## Please use a single # to start your custom comments
 
-$anyvm  $anyvm  ask
+dom0	$anyvm	ask
+$anyvm	$anyvm	ask
 


### PR DESCRIPTION
Prior to commit 981a11ce in qubes-core-admin-linux, this was allowed
accidentally as a bug.

This manifested itself as the silent inability to paste into any AppVM
after clicking the "Copy to Qubes clipboard" button in the log viewer
of qubes-manager.

Writing the new clipboard data in dom0 would work fine, and you would
get a notification that the copy was successful, but the paste path
would cause is_special_keypress() to bail early without warning due to
evaluate_clipboard_policy() failing with source_vm = "dom0".

I did not detect this sooner because if qubes-clipboard.bin.source had
a trailing newline, then evaluate_clipboard_policy() would not fail,
and my dom0 clipboard-copyout script produced such a trailing newline.