### PR TITLE
Fix always true conditional

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -2714,7 +2714,8 @@ static void parse_cmdline_vmname(Ghandles * g, int argc, char **argv)
 {
     int opt;
     optind = 1;
-
+    g->vmname[0] = '\0';
+    
     while ((opt = getopt_long(argc, argv, optstring, longopts, NULL)) != -1) {
         if (opt == 'N') {
             strncpy(g->vmname, optarg, sizeof(g->vmname));
@@ -2930,7 +2931,7 @@ static void parse_cmdline(Ghandles * g, int argc, char **argv)
     /* default target_domid to domid */
     if (!g->target_domid)
         g->target_domid = g->domid;
-    if (!g->vmname) {
+    if (g->vmname[0]=='\0') {
         fprintf(stderr, "domain name?");
         exit(1);
     }


### PR DESCRIPTION
While compiling with clang, this error comes up because `g->vmname` will always be non-NULL, although it may not have been set properly and therefore its value might be empty.
```
xside.c:2933:13: error: address of array 'g->vmname' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
    if (!g->vmname) {
        ~~~~^~~~~~
1 error generated.
<builtin>: recipe for target 'xside.o' failed
```
I have made a small fix for this: initializing the `g->vmname` char array with '\0' just before it is set, and making the change in the conditional to see it remains empty.