### PR TITLE
CLIPBOARD_DATA: fix sending of window id when pasting to VMs

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -824,9 +824,9 @@ static int is_special_keypress(Ghandles * g, const XKeyEvent * ev, XID remote_wi
                 fprintf(stderr, "secure paste\n");
             get_qubes_clipboard(g, &data, &len);
             if (len > 0) {
-                /* MSG_CLIPBOARD_DATA uses the window field to pass the length
-                   of the blob */
-                hdr.window = len;
+                /* MSG_CLIPBOARD_DATA used to use the window field to pass the length
+                   of the blob, be aware when working with old implementations. */
+                hdr.window = remote_winid;
                 hdr.untrusted_len = len;
                 real_write_message(g->vchan, (char *) &hdr, sizeof(hdr),
                         data, len);
@@ -2377,8 +2377,7 @@ static void handle_message(Ghandles * g)
     /* sanitized msg type */
     type = untrusted_hdr.type;
     if (type == MSG_CLIPBOARD_DATA) {
-        /* window field has special meaning here */
-        handle_clipboard_data(g, untrusted_hdr.window);
+        handle_clipboard_data(g, untrusted_hdr.untrusted_len);
         return;
     }
     l = list_lookup(g->remote2local, untrusted_hdr.window);


### PR DESCRIPTION
This sends the remote (the VM's) window id for `CLIPBOARD_DATA` events generated by `ctrl + shift + v`, like it is done with `CLIPBOARD_REQ` when you press `ctrl + shift +c`.
For Linux it does not make a big difference, since Xorg keeps track of which window currently has focused, but my implementation of the Qubes GUId protocol does not handle the concept of "focus" on a specific window, and it breaks my code that dispatches events to components based on window id.

This PR is interlinked with a PR to [qubes-gui-agent-linux](https://github.com/QubesOS/qubes-gui-agent-linux) because the Linux tooling currently ignores the length field and instead uses the window id field for transmitting the length, so it should not be merged without also merging my PR to that repository.

The Windows tooling seems to use a `QRexec`-based approach (`clipboard_paste.exe`) and as such should be untouched by this change. Please review before merging as I was not able to test this code.

EDIT: I am not aware of any other implementations, but if there are others they should of course also be given a fair warning before this is changed.