### PR TITLE
Fix Gtk-Warning: {Unknown tag "br" on line 1 char 365} 

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -129,7 +129,7 @@ static int ask_whether_verify_failed(Ghandles * g, const char *cond)
             "and is attempting to compromise the GUI daemon (Dom0 domain). In "
             "rare cases, however, it might be possible that a legitimate "
             "application trigger such condition (check the guid logs for more "
-            "information). <br/><br/>"
+            "information). \n\n"
             "Click \"Terminate\" to terminate this domain immediately, or "
             "\"Ignore\" to ignore this condition check and allow the GUI request "
             "to proceed.",
@@ -141,7 +141,7 @@ static int ask_whether_verify_failed(Ghandles * g, const char *cond)
             "and is attempting to compromise the GUI daemon (Dom0 domain). In "
             "rare cases, however, it might be possible that a legitimate "
             "application trigger such condition (check the guid logs for more "
-            "information). <br/><br/>"
+            "information). \n\n"
             "Do you allow this VM to continue running?",
          g->vmname);
 #endif


### PR DESCRIPTION
Fix Gtk-Warning: `{Unknown tag "br" on line 1 char 365}` that causes the dialog to not be shown.

It looks like it doesn't handle the `\n`s very well either, but currently you get a blank pop-up with two options: `[Ignore]  [Terminate]` that keeps popping up again when you click `Ignore`, and where the VM gets stuck in `Transient` state forever and can't easily be repaired/killed/handled using the Xen tools if you click `Terminate`. This PR doesn't fix that, but at least it makes it easier to seek help if the user can see the error message.