### PR TITLE
Actually dispatch resolution change notifications

### DIFF
--- a/screen-layout-handler/qubes-screen-layout-watches.desktop
+++ b/screen-layout-handler/qubes-screen-layout-watches.desktop
@@ -2,6 +2,6 @@
 Name=Qubes screen layout watcher
 Comment=Notifies Qubes VMs about screen layout changes
 Icon=qubes
-Exec=/usr/libexec/qubes/watch-screen-layout-changes qubes-monitor-layout-notify
+Exec=/usr/libexec/qubes/watch-screen-layout-changes qvm-start-gui --notify-monitor-layout --all
 Terminal=false
 Type=Application


### PR DESCRIPTION
I don't believe this is the best long-term fix (having anything besides
the gui-daemon involved seems like more moving parts than necessary),
but it's the least intrusive change which produces the desired overall
behavior right now.

    commit 25aa33cd3c6b5fc6a0689388a59fa9c7a720b95c
    Author: Wojtek Porczyk <woju@invisiblethingslab.com>
    Date:   Tue Mar 8 15:38:01 2016 +0100

        Remove qubes-monitor-layout-notify

        Was moved to core-admin.

is a lie. The script wasn't moved to core-admin... no such script exists
anymore. Instead, the code to get the AdminVM resolution and send it to
the guest VMs was integrated into qvm-start-gui in core-admin-client,
but only triggered on initial start of the VM and was never hooked up to
anything listening for randr events.

The fact that --all is required seems like a bug to me too, but lets
fix one thing at a time. Maybe qvm-start-gui shouldn't be involved at
all anyway.