### PR TITLE
Remove dependency on xl toolstack

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -179,8 +179,8 @@ static int ask_whether_verify_failed(Ghandles * g, const char *cond)
     case 0:    /* YES */
         return 0;
     case 1:    /* NO */
-        execl("/usr/sbin/xl", "xl", "destroy", g->vmname, (char*)NULL);
-        perror("Problems executing xl");
+        execl("/usr/bin/qvm-kill", "qvm-kill", g->vmname, (char*)NULL);
+        perror("Problems executing qvm-kill");
         exit(1);
     default:
         fprintf(stderr, "Problems executing %s ?\n", g->use_kdialog ? "kdialog" : "zenity");

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -179,7 +179,7 @@ static int ask_whether_verify_failed(Ghandles * g, const char *cond)
     case 0:    /* YES */
         return 0;
     case 1:    /* NO */
-        execl("/usr/bin/qvm-kill", "qvm-kill", g->vmname, (char*)NULL);
+        execl(QVM_KILL_PATH, "qvm-kill", g->vmname, (char*)NULL);
         perror("Problems executing qvm-kill");
         exit(1);
     default:

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -23,13 +23,18 @@
  *
  */
 
-/* default width of forced colorful border */
-#define BORDER_WIDTH 2
+/* various file paths */
+#define GUID_CONFIG_FILE "/etc/qubes/guid.conf"
+#define GUID_CONFIG_DIR "/etc/qubes"
 #define QUBES_CLIPBOARD_FILENAME "/var/run/qubes/qubes-clipboard.bin"
 #define QREXEC_CLIENT_PATH "/usr/lib/qubes/qrexec-client"
 #define QREXEC_POLICY_PATH "/usr/bin/qrexec-policy"
-#define GUID_CONFIG_FILE "/etc/qubes/guid.conf"
-#define GUID_CONFIG_DIR "/etc/qubes"
+#define KDIALOG_PATH "/usr/bin/kdialog"
+#define ZENITY_PATH "/usr/bin/zenity"
+
+/* default width of forced colorful border */
+#define BORDER_WIDTH 2
+
 /* this makes any X11 error fatal (i.e. cause exit(1)). This behavior was the
  * case for a long time before introducing this option, so nothing really have
  * changed  */
@@ -48,9 +53,6 @@
 #else
 #  define UNUSED(x) UNUSED_ ## x
 #endif
-
-#define KDIALOG_PATH "/usr/bin/kdialog"
-#define ZENITY_PATH "/usr/bin/zenity"
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -29,6 +29,7 @@
 #define QUBES_CLIPBOARD_FILENAME "/var/run/qubes/qubes-clipboard.bin"
 #define QREXEC_CLIENT_PATH "/usr/lib/qubes/qrexec-client"
 #define QREXEC_POLICY_PATH "/usr/bin/qrexec-policy"
+#define QVM_KILL_PATH "/usr/bin/qvm-kill"
 #define KDIALOG_PATH "/usr/bin/kdialog"
 #define ZENITY_PATH "/usr/bin/zenity"
 


### PR DESCRIPTION
Tested by setting a breakpoint in gdb before a VERIFY() and making the condition fail, rather than building a broken gui-agent. Worked as expected.