### PR TITLE
Correct note about "temporary" shm lifecycle

### DIFF
--- a/shmoverride/README
+++ b/shmoverride/README
@@ -18,7 +18,9 @@ and from which domain.
 	Somewhat unfortunately, the Xorg server tracks the already attached shmids.
 Therefore, it is not possible to pass the same "magic" value of synth_shmid
 to XShmAttach(...synth_shmid...). Before each XShmAttach, qubes_guid creates
-a temporary ("real") shared memory segment, sets cmd_pages->shmid to it, and
-then executes XShmAttach. This temporary segment is destroyed after
-XShmAttach completes.
-  
+a corresponding real shared memory segment, sets cmd_pages->shmid to it, and
+then executes XShmAttach. This segment is destroyed when the corresponding
+backing memory for the composition buffer is released, such as when the window
+is resized or closed. Keeping this additional otherwise-unused segment around
+for the whole life of the actual inter-domain shared-memory being used is
+necessary in order to prevent X from getting confused by shmid reuse.


### PR DESCRIPTION
The description sounds like a reasonable way to implement it, but it's apparently not how it's been implemented. I'm not sure why, but one theoretical reason might be to preemtively avoid potential bugs related to shmid recycling. For example, since X (allegedly) internally keeps track of shmids, if the temporary shmid matches one previously seen for a still-existing window, one might imagine bugs where the windows might end up with the same backing instead of X calling through to shmoverride.

In any case, this is confirmable by reading the code (look for `shmctl(..., IPC_RMID, ...)`), and by watching `/proc/sysvipc/shm`.