### PR TITLE
allow domid 0 as target

### DIFF
--- a/pulse/pacat-simple-vchan.c
+++ b/pulse/pacat-simple-vchan.c
@@ -613,7 +613,7 @@ int main(int argc, char *argv[])
                 domname = argv[i];
         }
     }
-    if (domid <= 0) { /* not-a-number returns 0 */
+    if (domid < 0) { /* not-a-number returns 0 */
         fprintf(stderr, "invalid domid\n");
         exit(1);
     }


### PR DESCRIPTION
no effort is made on trying to detect/handle the "this looks more like a vm name than a domid" case.
the "danger" is no more than getting a valid numeric but still entirely wrong domid.
this seems acceptable for something thats more internal infrastructure than user facing tooling.