### PR TITLE
Add keypress initiated wipe of VM clipboard

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -875,6 +875,41 @@ static int is_special_keypress(Ghandles * g, const XKeyEvent * ev, XID remote_wi
 
         return 1;
     }
+
+    /* blank */
+    if (((int)ev->state & SPECIAL_KEYS_MASK) == g->blank_seq_mask
+        && ev->keycode == XKeysymToKeycode(g->display, g->blank_seq_key)) {
+        if (ev->type != KeyPress)
+            return 1;
+        inter_appviewer_lock(g, 1);
+        clipboard_file_xevent_time = get_clipboard_file_xevent_timestamp();
+        if (clipboard_file_xevent_time > ev->time) {
+            /* some other clipboard operation happened in the meantime, discard
+             * request */
+            inter_appviewer_lock(g, 0);
+            fprintf(stderr,
+                    "received clipboard xevent after some other clipboard op, discarding\n");
+            return 1;
+        }
+        if (g->qrexec_clipboard) {
+            if (g->log_level > 0)
+                fprintf(stderr, "secure blank is not supported for stubdom GUI\n");
+        } else {
+            hdr.type = MSG_CLIPBOARD_DATA;
+            if (g->log_level > 0)
+                fprintf(stderr, "secure blank\n");
+            len = 0;
+            /* MSG_CLIPBOARD_DATA uses the window field to pass the length
+               of the blob */
+            hdr.window = len;
+            hdr.untrusted_len = len;
+            real_write_message(g->vchan, (char *) &hdr, sizeof(hdr),
+                data, len);
+        }
+        inter_appviewer_lock(g, 0);
+
+        return 1;
+    }
     return 0;
 }
 
@@ -3177,6 +3212,8 @@ static void load_default_config_values(Ghandles * g)
     g->copy_seq_key = XK_c;
     g->paste_seq_mask = ControlMask | ShiftMask;
     g->paste_seq_key = XK_v;
+    g->blank_seq_mask = ControlMask | ShiftMask;
+    g->blank_seq_key = XK_b;
     g->allow_fullscreen = 0;
     g->startup_timeout = 45;
     g->audio_low_latency = 1;
@@ -3245,6 +3282,11 @@ static void parse_vm_config(Ghandles * g, config_setting_t * group)
          config_setting_get_member(group, "secure_paste_sequence"))) {
         parse_key_sequence(config_setting_get_string(setting),
                    &g->paste_seq_mask, &g->paste_seq_key);
+    }
+    if ((setting =
+         config_setting_get_member(group, "secure_blank_sequence"))) {
+        parse_key_sequence(config_setting_get_string(setting),
+                   &g->blank_seq_mask, &g->blank_seq_key);
     }
 
     if ((setting =

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -182,6 +182,8 @@ struct _global_handles {
     KeySym copy_seq_key;    /* key for secure-copy key sequence */
     int paste_seq_mask;    /* modifiers mask for secure-paste key sequence */
     KeySym paste_seq_key;    /* key for secure-paste key sequence */
+    int blank_seq_mask;    /* modifiers mask for secure-paste key sequence */
+    KeySym blank_seq_key;    /* key for secure-paste key sequence */
     int qrexec_clipboard;    /* 0: use GUI protocol to fetch/put clipboard, 1: use qrexec */
     int use_kdialog;    /* use kdialog for prompts (default on KDE) or zenity (default on non-KDE) */
     int audio_low_latency; /* set low-latency mode while starting pacat-simple-vchan */


### PR DESCRIPTION
When using a password manager in an isolated VM and copying passwords from
there, it is convenient to have a quick method to wipe the clipboard of the
active VM after the password has been used. This adds the keyboard shortcut
Ctrl+Shift+B (for blank) as default to paste a single space into the VM
clipboard.

Note that this is a proof-of-concept/request-for-comments at this stage, not including support for
stubdom VMs nor having been thoroughly tested. Also, actually blanking the clipboard instead of replacing it with a single space would be nicer. But I wanted to see if there's any interest in this feature before going forward with development :)

Also note that this has been tested against r4.0 with the fc25 dom0, but not (yet) on fc29 dom0.