### PR TITLE
Fix tray icon coloring code - do not crop/dislocate icon fragments

### DIFF
--- a/gui-daemon/trayicon.c
+++ b/gui-daemon/trayicon.c
@@ -269,7 +269,7 @@ void tint_tray_and_update(Ghandles *g, struct windowdata *vm_window,
         }
     }
     XPutImage(g->display, vm_window->local_winid,
-            g->context, image, x, x, x, x, w, h);
+            g->context, image, 0, 0, x, y, w, h);
     XDestroyImage(image);
     XFreePixmap(g->display, pixmap);
 }


### PR DESCRIPTION
When only part of the icon was redrawn, the code used wrong coordinates
and instead of putting that part back at the correct (x, y) coordinates,
it put it at (x, x). Additionally, it used cropped part of that
icon, because of again using (x, x) start coordinates (in an image already
containing just updated fragment) instead of (0, 0).

It worked accidentally only when the application always redraw the whole
icon (or at least its top-left part - so x=y=0). Which apparently is a
very common thing applications do.

Fixes QubesOS/qubes-issues#5704