### PR TITLE
Currently disable failing builds for CentOS 7

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,2 +1,4 @@
+ifneq ($(DIST),centos7)
 RPM_SPEC_FILES := rpm_spec/gui-daemon.spec
+endif
 DEBIAN_BUILD_DIRS := debian


### PR DESCRIPTION
Should be fixed by Marek's PR: https://github.com/QubesOS/qubes-gui-daemon/pull/26