### PR TITLE
pulse: starting/stopping improvements

### DIFF
--- a/pulse/pacat-simple-vchan.h
+++ b/pulse/pacat-simple-vchan.h
@@ -6,6 +6,8 @@
 #include <dbus/dbus-glib-bindings.h>
 #include <libvchan.h>
 
+#define PACAT_PIDFILE_PATH_TPL "/var/run/qubes/pacat.%d"
+
 struct userdata {
     pa_mainloop_api *mainloop_api;
     GMainLoop *loop;


### PR DESCRIPTION
1. Terminate when the target domain is killed
2. Create a pidfile (/var/run/qubes/pacat.<XID>) to prevent multiple instances.

The second one will only be effective with #35, as otherwise pacat-simple-vchan
is started as root (so the pidfile is unreadable for the normal user), but also
is killed with SIGTERM and does not cleanup the pid file.

Fixes QubesOS/qubes-issues#5760