### PR TITLE
shmoverride: fill shm_perm when faking shmctl(IPC_STAT) output

### DIFF
--- a/shmoverride/shmoverride.c
+++ b/shmoverride/shmoverride.c
@@ -224,6 +224,7 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
     }
 
     memset(&buf->shm_perm, 0, sizeof(buf->shm_perm));
+    buf->shm_perm.mode = 0666;
     buf->shm_segsz = segsz;
 
     return 0;


### PR DESCRIPTION
... for a cross-vm memory mapping. The fact that the shmctl was
intercepted by shmoverride, means the server should use the mapping. X
server checks if the shm region has sufficient access (for given
client) - since the check is already implicitly done by shmoverride,
announce 0666 mode and don't care about uid/gid.

Fixes QubesOS/qubes-issues#5896