### PR TITLE
Allow overriding configuration file

### DIFF
--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -1,57 +1,62 @@
 # Default configuration file for Qubes GUI daemon
-#  For syntax go http://www.hyperrealm.com/libconfig/libconfig_manual.html
+# (For syntax go http://www.hyperrealm.com/libconfig/libconfig_manual.html)
+#
+# TODO: This file will be superseded by auto-generated configuration from
+# qvm-features.
 
 global: {
-  # default values
-  #allow_fullscreen = false;
-  #override_redirect_protection = true;
-  #allow_utf8_titles = false;
-  # Change the lines below to change the secure copy and paste keyboard shortcuts
-  #    Before changing secure_(copy|paste)_sequence below because you need
-  #    Ctrl-Shift-(c|v) for normal terminal copy&paste, please note that you
-  #    can also use Ctrl-Ins and Shift-Ins for that (thus: no need to change).
-  #    If you still want to change, here is a list of valid modifier key names:
-  #    "Ctrl", "Shift", "Mod4" (Windows key) 
-  #secure_copy_sequence = "Ctrl-Shift-c";
-  #secure_paste_sequence = "Ctrl-Shift-v";
-  #windows_count_limit = 500;
-  #audio_low_latency = true;
-  # Change the line below to set how tray icons are handled
-  #     see `man qubes-guid` for options
-  #trayicon_mode = "border1";
-  #startup_timeout = 45;
-};
-
-# most of setting can be set per-VM basis
-
-VM: {
-  # Example of a VM with UTF-8 title characters allowed
-  #example-work-vm: {
-  #  allow_utf8_titles = true;
-  #};
-  # Example of a VM with full screen access
-  #    see https://www.qubes-os.org/doc/full-screen-mode/
-  #    for discussion of risks and alternatives
-  #example-media-vm: {
-  #  allow_fullscreen = true;
-  #};
-  # Example of a VM that may create very large windows that
-  # have the override_redirect flag set. This flag allows a
-  # window to unconditionally cover all other windows and
-  # causes the window manager to make it impossible to
-  # minimize or hide the window in question.
+  # Allow full-screen access
   #
-  # Qubes OS will prevent a window having the override_redirect
-  # flag set from covering more than 90% of the screen as a
-  # protection measure. The protection measure unsets this
-  # flag and lets the window manager (and hence the user)
-  # control the window.
+  # See https://www.qubes-os.org/doc/full-screen-mode/
+  # for discussion of risks and alternatives.
   #
-  # If this causes issues with a VM's or an application's usage,
-  # please adapt this example to disable this protection for
-  # a specific VM.
-  #example-vm-with-large-unusual-windows: {
-  #  override_redirect_protection = false;
-  #}
-};
+  # allow_fullscreen = false;
 
+  # override_redirect protection
+  #
+  # You might disable this for of a VM that may create very large windows that
+  # have the override_redirect flag set. This flag allows a window to
+  # unconditionally cover all other windows and causes the window manager to
+  # make it impossible to minimize or hide the window in question.
+  #
+  # Qubes OS will prevent a window having the override_redirect flag set from
+  # covering more than 90% of the screen as a protection measure. The
+  # protection measure unsets this flag and lets the window manager (and hence
+  # the user) control the window.
+  #
+  # If this causes issues with a VM's or an application's usage, you can
+  # disable this protection for a specific VM.
+  #
+  # override_redirect_protection = true;
+
+  # Allow UTF-8 title characters
+  #
+  # allow_utf8_titles = false;
+
+  # Secure copy and paste keyboard shortcuts
+  #
+  # Before changing secure_(copy|paste)_sequence below because you need
+  # Ctrl-Shift-(c|v) for normal terminal copy&paste, please note that you can
+  # also use Ctrl-Ins and Shift-Ins for that (thus: no need to change).  If you
+  # still want to change, here is a list of valid modifier key names: "Ctrl",
+  # "Shift", "Mod4" (Windows key)
+  #
+  # secure_copy_sequence = "Ctrl-Shift-c";
+  # secure_paste_sequence = "Ctrl-Shift-v";
+
+  # Limit number of windows
+  #
+  # windows_count_limit = 500;
+
+  # Low-latency audio mode (TODO unused?)
+  #
+  # audio_low_latency = true;
+
+  # Set how tray icons are handled. See `man qubes-guid` for options.
+  #
+  # trayicon_mode = "border1";
+
+  # Timeout when waiting for qubes-gui-agent
+  #
+  # startup_timeout = 45;
+}

--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -1,8 +1,9 @@
 # Default configuration file for Qubes GUI daemon
 # (For syntax go http://www.hyperrealm.com/libconfig/libconfig_manual.html)
-#
-# TODO: This file will be superseded by auto-generated configuration from
-# qvm-features.
+
+# EDITING THIS FILE WILL NOT HAVE ANY EFFECT! It is not read by the GUI daemon
+# anymore, and is left here for reference only. To configure the GUI daemon,
+# use qvm-features (see 'man qvm-features' for details).
 
 global: {
   # Allow full-screen access

--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -48,10 +48,6 @@ global: {
   #
   # windows_count_limit = 500;
 
-  # Low-latency audio mode (TODO unused?)
-  #
-  # audio_low_latency = true;
-
   # Set how tray icons are handled. See `man qubes-guid` for options.
   #
   # trayicon_mode = "border1";

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -175,6 +175,7 @@ struct _global_handles {
     int volatile reload_requested;
     pid_t pulseaudio_pid;
     /* configuration */
+    char config_path[64]; /* configuration file path (initialized to default) */
     int log_level;        /* log level */
     int startup_timeout;
     int nofork;               /* do not fork into background - used during guid restart */


### PR DESCRIPTION
Remove per-VM configuration, but allow providing a path to the
configuration file. This is in order to move GUI daemon
configuration to qvm-features.

(WIP until the other part of the change is done)