### PR TITLE
Prevent VM notifications from appearing on top of xscreensaver

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -245,11 +245,23 @@ int x11_error_handler(Display * dpy, XErrorEvent * ev)
 {
     /* log the error */
     dummy_handler(dpy, ev);
-    if ((ev->request_code == X_DestroyWindow || ev->request_code == X_UnmapWindow)
+    if ((ev->request_code == X_DestroyWindow
+         || ev->request_code == X_UnmapWindow
+         || ev->request_code == X_ConfigureWindow
+         || ev->request_code == X_GetProperty)
             && ev->error_code == BadWindow) {
         fprintf(stderr, "  someone else already destroyed this window, ignoring\n");
         return 0;
     }
+    /* Permit XGetWindowAttributes errors, as long as they're not for root_win */
+    if (ev->request_code == X_GetWindowAttributes &&
+        ev->error_code == BadWindow &&
+        ev->resourceid != ghandles.root_win) {
+
+        fprintf(stderr, "  someone else already destroyed this window, ignoring\n");
+        return 0;
+    }
+
     if (ev->request_code == ghandles.shm_major_opcode
             && ev->minor_code == X_ShmAttach
             && ev->error_code == BadAccess) {
@@ -1618,11 +1630,14 @@ static void process_xevent_expose(Ghandles * g, const XExposeEvent * ev)
  * after some checks, send to relevant window in VM */
 static void process_xevent_mapnotify(Ghandles * g, const XMapEvent * ev)
 {
+    int ret;
     XWindowAttributes attr;
     CHECK_NONMANAGED_WINDOW(g, ev->window);
     if (vm_window->is_mapped)
         return;
-    XGetWindowAttributes(g->display, vm_window->local_winid, &attr);
+    ret = XGetWindowAttributes(g->display, vm_window->local_winid, &attr);
+    if (!ret)
+        return;
     if (attr.map_state != IsViewable && !vm_window->is_docked) {
         /* Unmap windows that are not visible on vmside.
          * WM may try to map non-viewable windows ie. when
@@ -2326,20 +2341,21 @@ static void handle_wmflags(Ghandles * g, struct windowdata *vm_window)
 
 /* Check if we should keep this window on top of others */
 static bool should_keep_on_top(Ghandles *g, Window window) {
+    int ret;
     XWindowAttributes attr;
     XClassHint hint;
     bool result;
     int i;
 
     /* Check if the window has override_redirect attribute, and is mapped. */
-    XGetWindowAttributes(g->display, window, &attr);
-    if (!(attr.override_redirect && attr.map_state == IsViewable)) {
+    ret = XGetWindowAttributes(g->display, window, &attr);
+    if (!(ret && attr.override_redirect && attr.map_state == IsViewable))
         return false;
-    }
 
     /* Check if this is a dom0 screensaver window by looking at window class.
      * (VM windows have a prefix, so this is not spoofable by a VM). */
-    if (XGetClassHint(g->display, window, &hint) == 0)
+    ret = XGetClassHint(g->display, window, &hint);
+    if (!ret)
         return false;
 
     result = false;

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -53,6 +53,8 @@
 
 #define MAX_EXTRA_PROPS 10
 
+#define MAX_SCREENSAVER_NAMES 10
+
 #ifdef __GNUC__
 #  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
 #else
@@ -196,6 +198,7 @@ struct _global_handles {
     int trayicon_border; /* position of trayicon border - 0 - no border, 1 - at the edges, 2 - 1px from the edges */
     bool trayicon_tint_reduce_saturation; /* reduce trayicon saturation by 50% (available only for "tint" mode) */
     bool trayicon_tint_whitehack; /* replace white pixels with almost-white 0xfefefe (available only for "tint" mode) */
+    char *screensaver_names[MAX_SCREENSAVER_NAMES]; /* WM_CLASS names for windows detected as screensavers */
     Cursor *cursors;  /* preloaded cursors (using XCreateFontCursor) */
 };
 


### PR DESCRIPTION
Detect a screensaver window by override_redirect, map state (an
inactive window is unmapped), and window class. Use XRestackWindows
to put newly appearing windows below such a window.

To test:
1. run in VM: while true; do notify-send "hey"; sleep 1; done
2. lock screen and check if notifications appear.

The problem doesn't seem to appear on i3lock. I haven't checked
KDE.

See QubesOS/qubes-issues#5908.