### PR TITLE
icon-receiver: Retry X connection on error

### DIFF
--- a/window-icon-updater/icon-receiver
+++ b/window-icon-updater/icon-receiver
@@ -402,11 +402,18 @@ def main():
 
     rcvd = IconReceiver()
 
+    def handle_exception(loop, context):
+        e = context.get('exception')
+        if isinstance(e, xcb.ConnectionException):
+            logging.error("Connection error: %s", e)
+            sys.exit(1)
+
     loop = asyncio.get_event_loop()
     tasks = [
         rcvd.handle_events(),
         rcvd.handle_clients(),
     ]
+    loop.set_exception_handler(handle_exception)
     loop.run_until_complete(asyncio.gather(*tasks))
 
 


### PR DESCRIPTION
This adds an exception handler to the event loop, which will try to reestablish the xcb connection on error. The connection logic is pulled out of `IconReceiver.__init__` to a new `connect` method, to support this.

This does mitigate https://github.com/QubesOS/qubes-issues/issues/5979, but I hesitate to call it a complete fix. What happens for me is that `icon-receiver` still fails to connect for 6-7 seconds, during which time it's still spamming `.xsession-errors.old`, but it is eventually able to connect and the torrent of error logging stops.
