### PR TITLE
Fix handling X11 exit

### DIFF
--- a/gui-common/txrx-vchan.c
+++ b/gui-common/txrx-vchan.c
@@ -35,6 +35,8 @@ int vchan_is_closed = 0;
  */
 int double_buffered = 1;
 
+int wait_for_vchan_or_argfd_once(libvchan_t *vchan, int nfd, int *fd, fd_set * retset);
+
 void vchan_register_at_eof(void (*new_vchan_at_eof)(void)) {
     vchan_at_eof = new_vchan_at_eof;
 }
@@ -93,6 +95,8 @@ int read_data(libvchan_t *vchan, char *buf, int size)
     int written = 0;
     int ret;
     while (written < size) {
+        while (!libvchan_data_ready(vchan))
+            wait_for_vchan_or_argfd_once(vchan, 0, NULL, NULL);
         ret = libvchan_read(vchan, buf + written, size - written);
         if (ret <= 0)
             handle_vchan_error(vchan, "read data");

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -107,6 +107,7 @@ static Ghandles ghandles;
  */
 static bool shm_attach_failed = false;
 
+static int (*default_x11_io_error_handler)(Display *dpy);
 static void inter_appviewer_lock(Ghandles *g, int mode);
 static void release_mapped_mfns(Ghandles * g, struct windowdata *vm_window);
 static void print_backtrace(void);
@@ -281,6 +282,26 @@ int x11_error_handler(Display * dpy, XErrorEvent * ev)
 #endif
     return 0;
 }
+
+/* 
+ * The X11 IO error handler. It is supposed to cleanup things and do _not_
+ * return (should terminate the process).
+ */
+static int x11_io_error_handler(Display * dpy)
+{
+    /* The default error handler below will call exit(1), which will then call
+     * release_all_mapped_mfns (registerd with atexit(3)), which would try to
+     * release window images with XShmDetach.
+     * When the IO error occurs in X11 it is no longer safe/possible to
+     * communicate with the X server. Clean window images without calling to
+     * X11. And hope that X server will call XShmDetach internally when
+     * cleaning windows of disconnected client */
+    release_all_shm_no_x11_calls();
+    if (default_x11_io_error_handler)
+        default_x11_io_error_handler(dpy);
+    exit(1);
+}
+
 
 /* prepare graphic context for painting colorful frame and set RGB value of the
  * color */
@@ -3723,6 +3744,7 @@ int main(int argc, char **argv)
     }
     mkghandles(&ghandles);
     XSetErrorHandler(x11_error_handler);
+    default_x11_io_error_handler = XSetIOErrorHandler(x11_io_error_handler);
     double_buffer_init();
     ghandles.vchan = libvchan_client_init(ghandles.domid, 6000);
     if (!ghandles.vchan) {


### PR DESCRIPTION
When X server terminates (for example user logout), the X11 IO error
handler may be called, which terminates the process. Generally this is
fine, but gui-daemon has atexit(3) handler that tries to communicate
with X server (release_all_mapped_mfns() call). This operation fails
miserably (since X11 connection is broken) and in some cases makes the
process skip other atexit(3) handlers (if it crashes during some earlier
of them).  Especially it may cause skipping pidfile cleanup. Not
cleaning up the pidfile will prevent starting gui-daemon for this domain
after X server restart.

Fixes QubesOS/qubes-issues#6155