### PR TITLE
More protection vs override redirect windows

### DIFF
--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -56,4 +56,8 @@ global: {
   # Timeout when waiting for qubes-gui-agent
   #
   # startup_timeout = 45;
+
+  # Taskbar height
+  #
+  # taskbar_height = 20
 }

--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -56,8 +56,4 @@ global: {
   # Timeout when waiting for qubes-gui-agent
   #
   # startup_timeout = 45;
-
-  # Taskbar height
-  #
-  # taskbar_height = 20
 }

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -478,9 +478,11 @@ static void update_work_area(Ghandles *g) {
     uint32_t current_desktop = (uint32_t)*scratch;
     XFree(scratch);
     ret = XGetWindowProperty(g->display, g->root_win, g->wm_workarea,
-            current_desktop * 4, 4, False, XA_CARDINAL, &act_type, &act_fmt,
+            current_desktop * desktop_coordinates_size,
+            desktop_coordinates_size, False, XA_CARDINAL, &act_type, &act_fmt,
             &nitems, &bytesleft, (unsigned char**)&scratch);
-    if (ret != Success || nitems != 4 || act_fmt != 32 || act_type != XA_CARDINAL) {
+    if (ret != Success || nitems != desktop_coordinates_size || act_fmt != 32 ||
+        act_type != XA_CARDINAL) {
         if (None == act_fmt && !act_fmt && !bytesleft) {
             g->work_x = 0;
             g->work_y = 0;
@@ -495,7 +497,7 @@ static void update_work_area(Ghandles *g) {
                 stderr);
         exit(1);
     }
-    for (int s = 0; s < 4; ++s) {
+    for (int s = 0; s < desktop_coordinates_size; ++s) {
         if (scratch[s] > max_display_width) {
             fputs("Absurd work area, crashing\n", stderr);
             abort();
@@ -1225,9 +1227,11 @@ static void moveresize_vm_window(Ghandles * g, struct windowdata *vm_window)
     if (!vm_window->is_docked) {
         /* we have window content coordinates, but XMoveResizeWindow requires
          * left top *border* pixel coordinates (if any border is present). */
-        ret = XGetWindowProperty(g->display, vm_window->local_winid, g->frame_extents, 0, 4,
-                False, XA_CARDINAL, &act_type, &act_fmt, &nitems, &bytesleft, (unsigned char**)&frame_extents);
-        if (ret == Success && nitems == 4) {
+        ret = XGetWindowProperty(g->display, vm_window->local_winid,
+                g->frame_extents, 0, desktop_coordinates_size,
+                False, XA_CARDINAL, &act_type, &act_fmt, &nitems, &bytesleft,
+                (unsigned char**)&frame_extents);
+        if (ret == Success && nitems == desktop_coordinates_size) {
             x = vm_window->x - frame_extents[0];
             y = vm_window->y - frame_extents[2];
             XFree(frame_extents);

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -543,7 +543,7 @@ static void mkghandles(Ghandles * g)
     g->wm_state_fullscreen = intern_atom(g, "_NET_WM_STATE_FULLSCREEN", False);
     g->wm_state_demands_attention = intern_atom(g, "_NET_WM_STATE_DEMANDS_ATTENTION", False);
     g->wm_state_hidden = intern_atom(g, "_NET_WM_STATE_HIDDEN", False);
-    g->wm_workarea = intern_atom(g, "_NET_WORKAREA", True);
+    g->wm_workarea = intern_atom(g, "_NET_WORKAREA", False);
     g->frame_extents = intern_atom(g, "_NET_FRAME_EXTENTS", False);
     g->wm_state_maximized_vert = intern_atom(g, "_NET_WM_STATE_MAXIMIZED_VERT", False);
     g->wm_state_maximized_horz = intern_atom(g, "_NET_WM_STATE_MAXIMIZED_HORZ", False);

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -77,10 +77,7 @@
 static Ghandles ghandles;
 
 /* macro used to verify data from VM */
-#define VERIFY(x) if (!(x)) { \
-        if (ask_whether_verify_failed(g, __STRING(x))) \
-            return; \
-    }
+#define VERIFY(x) do if (!(x) && ask_whether_verify_failed(g, __STRING(x))) return; while(0)
 
 /* calculate virtual width */
 #define XORG_DEFAULT_XINC 8
@@ -161,8 +158,7 @@ static int ask_whether_verify_failed(Ghandles * g, const char *cond)
             "application trigger such condition (check the guid logs for more "
             "information). \n\n"
             "Click “Terminate” to terminate this domain immediately, or "
-            "“Ignore” to ignore this condition check and allow the GUI request "
-            "to proceed.",
+            "“Ignore” to ignore this GUI request.",
          g->vmname);
 #else
     snprintf(text, sizeof(text),
@@ -207,7 +203,7 @@ static int ask_whether_verify_failed(Ghandles * g, const char *cond)
 //    case 2:    /*cancel */
 //        break;
     case 0:    /* YES */
-        return 0;
+        return 1;
     case 1:    /* NO */
         execl(QVM_KILL_PATH, "qvm-kill", g->vmname, (char*)NULL);
         perror("Problems executing qvm-kill");
@@ -217,7 +213,7 @@ static int ask_whether_verify_failed(Ghandles * g, const char *cond)
         exit(1);
     }
     /* should never happen */
-    return 1;
+    abort();
 }
 
 #ifdef MAKE_X11_ERRORS_FATAL
@@ -948,6 +944,8 @@ static int evaluate_clipboard_policy(Ghandles * g) {
     }
     return WEXITSTATUS(status) == 0;
 }
+
+_Static_assert(CURSOR_X11_MAX == CURSOR_X11 + XC_num_glyphs, "protocol bug");
 
 /* handle VM message: MSG_CURSOR */
 static void handle_cursor(Ghandles *g, struct windowdata *vm_window)

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -586,7 +586,7 @@ static void mkghandles(Ghandles * g)
             fprintf(stderr, "Icon size: %lux%lu\n", g->icon_data[0], g->icon_data[1]);
         }
     }
-    g->inter_appviewer_lock_fd = open("/var/run/qubes/appviewer.lock",
+    g->inter_appviewer_lock_fd = open("/run/qubes/appviewer.lock",
             O_RDWR | O_CREAT, 0666);
     if (g->inter_appviewer_lock_fd < 0) {
         perror("create lock");
@@ -3680,7 +3680,7 @@ static void parse_config(Ghandles * g)
 static char *guid_fs_flag(const char *type, int domid)
 {
     static char buf[256];
-    snprintf(buf, sizeof(buf), "/var/run/qubes/guid-%s.%d",
+    snprintf(buf, sizeof(buf), "/run/qubes/guid-%s.%d",
          type, domid);
     return buf;
 }
@@ -3872,8 +3872,8 @@ int main(int argc, char **argv)
             close(logfd);
     }
 
-    if (chdir("/var/run/qubes")) {
-        perror("chdir /var/run/qubes");
+    if (chdir("/run/qubes")) {
+        perror("chdir /run/qubes");
         exit(1);
     }
     errno = 0;

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -142,6 +142,7 @@ struct _global_handles {
     Atom wm_state_demands_attention; /* Atom: _NET_WM_STATE_DEMANDS_ATTENTION */
     Atom wm_state_hidden;    /* Atom: _NET_WM_STATE_HIDDEN */
     Atom wm_workarea;      /* Atom: _NET_WORKAREA */
+    Atom wm_current_desktop;      /* Atom: _NET_CURRENT_DESKTOP */
     Atom frame_extents; /* Atom: _NET_FRAME_EXTENTS */
     Atom wm_state_maximized_vert; /* Atom: _NET_WM_STATE_MAXIMIZED_VERT */
     Atom wm_state_maximized_horz; /* Atom: _NET_WM_STATE_MAXIMIZED_HORZ */
@@ -202,7 +203,7 @@ struct _global_handles {
     bool disable_override_redirect; /* Disable “override redirect” windows */
     char *screensaver_names[MAX_SCREENSAVER_NAMES]; /* WM_CLASS names for windows detected as screensavers */
     Cursor *cursors;  /* preloaded cursors (using XCreateFontCursor) */
-    int taskbar_height;  /* do not allow a window to overlap these pixels */
+    int work_x, work_y, work_width, work_height;  /* do not allow a window to go beyond these bounds */
 };
 
 typedef struct _global_handles Ghandles;

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -141,6 +141,7 @@ struct _global_handles {
     Atom wm_state_fullscreen; /* Atom: _NET_WM_STATE_FULLSCREEN */
     Atom wm_state_demands_attention; /* Atom: _NET_WM_STATE_DEMANDS_ATTENTION */
     Atom wm_state_hidden;    /* Atom: _NET_WM_STATE_HIDDEN */
+    Atom wm_workarea;      /* Atom: _NET_WORKAREA */
     Atom frame_extents; /* Atom: _NET_FRAME_EXTENTS */
     Atom wm_state_maximized_vert; /* Atom: _NET_WM_STATE_MAXIMIZED_VERT */
     Atom wm_state_maximized_horz; /* Atom: _NET_WM_STATE_MAXIMIZED_HORZ */

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -198,8 +198,10 @@ struct _global_handles {
     int trayicon_border; /* position of trayicon border - 0 - no border, 1 - at the edges, 2 - 1px from the edges */
     bool trayicon_tint_reduce_saturation; /* reduce trayicon saturation by 50% (available only for "tint" mode) */
     bool trayicon_tint_whitehack; /* replace white pixels with almost-white 0xfefefe (available only for "tint" mode) */
+    bool disable_override_redirect; /* Disable “override redirect” windows */
     char *screensaver_names[MAX_SCREENSAVER_NAMES]; /* WM_CLASS names for windows detected as screensavers */
     Cursor *cursors;  /* preloaded cursors (using XCreateFontCursor) */
+    int taskbar_height;  /* do not allow a window to overlap these pixels */
 };
 
 typedef struct _global_handles Ghandles;


### PR DESCRIPTION
This adds two features:

- A flag to disable override redirect windows entirely.  This will break
  many applications.
- A distance that any window must have from the top of the screen.  This
  prevents an override redirect window from drawing over the taskbar
  from the GUI domain.