### PR TITLE
Fix clipboard stop working after ~50 days of uptime

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -799,7 +799,9 @@ static void handle_clipboard_data(Ghandles * g, unsigned int untrusted_len)
     }
     inter_appviewer_lock(g, 1);
     clipboard_file_xevent_time = get_clipboard_file_xevent_timestamp();
-    if (clipboard_file_xevent_time > g->clipboard_xevent_time) {
+    /* X11 time is just 32-bit miliseconds counter, which make it wrap every
+     * ~50 days - something that is realistic. Handle that wrapping too. */
+    if (clipboard_file_xevent_time - g->clipboard_xevent_time < (1UL<<31)) {
         /* some other clipboard operation happened in the meantime, discard
          * request */
         inter_appviewer_lock(g, 0);
@@ -944,7 +946,9 @@ static int is_special_keypress(Ghandles * g, const XKeyEvent * ev, XID remote_wi
             return 1;
         inter_appviewer_lock(g, 1);
         clipboard_file_xevent_time = get_clipboard_file_xevent_timestamp();
-        if (clipboard_file_xevent_time > ev->time) {
+        /* X11 time is just 32-bit miliseconds counter, which make it wrap every
+         * ~50 days - something that is realistic. Handle that wrapping too. */
+        if (clipboard_file_xevent_time - ev->time < (1UL<<31)) {
             /* some other clipboard operation happened in the meantime, discard
              * request */
             inter_appviewer_lock(g, 0);


### PR DESCRIPTION
We use X11 event time to detect if any other clipboard operation
happened between user trigger (via key combo) and the actual operation
happens (like - VM sends the clipboard content). But when the X11 timer
wraps (every 2^32 ms = ~50 days), the check fails as the "clipboard
file" event time (just before the wrap) will be greater than the current
event time (just after the wrap).
Detect the wrap by checking if the difference is no larger than half of
the timer range.

Theoretically this could still fail if a single clipboard operation will
take ~25 days _and no other clipboard operation happens in the meantime_.
If another operation happens in the meantime, it _should_ fail.

Fixes QubesOS/qubes-issues#2189