### PR TITLE
Enforce locale for help2man

### DIFF
--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -39,7 +39,7 @@ qubes-guid: $(OBJS)
 		`pkg-config --libs libnotify`
 
 qubes-guid.1: qubes-guid
-	help2man --version-string=`cat ../version` --no-info --name="Qubes GUI daemon" ./qubes-guid  > qubes-guid.1
+	LC_ALL=C help2man --version-string=`cat ../version` --no-info --name="Qubes GUI daemon" ./qubes-guid  > qubes-guid.1
 
 clean:
 	rm -f qubes-guid *.o *~


### PR DESCRIPTION
There is random build issues when having encodings like RK1048. It
appears notably in reprotest.

Related issues:
- https://gitlab.com/QubesOS/qubes-gui-daemon/-/jobs/900656529#L808
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894217