### PR TITLE
Use XCB instead of Xlib for shared memory

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,9 +10,10 @@ Build-Depends:
  libvchan-xen-dev,
  python3-dev,
  libpulse-dev,
- libxext-dev,
  libxrandr-dev,
  libxcb1-dev,
+ libxcb-util0-dev,
+ libxcb-shm0-dev,
  libx11-xcb-dev,
  libconfig-dev,
  libpng-dev,
@@ -21,8 +22,8 @@ Build-Depends:
  help2man
 Standards-Version: 4.1.3
 Homepage: https://qubes-os.org/
-#Vcs-Browser: https://github.com/QubesOS/qubes-gui-daemon
-#Vcs-Git: https://github.com/QubesOS/qubes-gui-daemon.git
+Vcs-Browser: https://github.com/QubesOS/qubes-gui-daemon
+Vcs-Git: https://github.com/QubesOS/qubes-gui-daemon.git
 
 Package: qubes-gui-daemon
 Architecture: any

--- a/gui-common/error.c
+++ b/gui-common/error.c
@@ -62,6 +62,9 @@ int dummy_handler(Display * dpy, XErrorEvent * ev)
                       sizeof(buf));
         fprintf(stderr, "                 Minor opcode: %d (%s)\n",
             ev->minor_code, buf);
+    }  else {
+        fprintf(stderr, "                 Minor opcode: %d\n",
+            ev->minor_code);
     }
 
     /* Provide value information */

--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -22,7 +22,7 @@
 MAKEFLAGS := -rR
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 CC=gcc
-pkgs := x11 xext x11-xcb xcb glib-2.0 $(VCHAN_PKG) libpng libnotify libconfig
+pkgs := x11 x11-xcb xcb xcb-shm xcb-aux glib-2.0 $(VCHAN_PKG) libpng libnotify libconfig
 objs := xside.o png.o trayicon.o ../gui-common/double-buffer.o ../gui-common/txrx-vchan.o \
 	../gui-common/error.o list.o
 extra_cflags := -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC \

--- a/gui-daemon/trayicon.c
+++ b/gui-daemon/trayicon.c
@@ -26,6 +26,7 @@
 #include <X11/Xutil.h>
 #include <math.h>
 #include "xside.h"
+#include <util.h>
 
 /* initialization required for TRAY_BACKGROUND mode */
 void init_tray_bg(Ghandles *g) {
@@ -45,7 +46,7 @@ void fill_tray_bg_and_update(Ghandles *g, struct windowdata *vm_window,
     size_t data_sz;
     int xp, yp;
 
-    if (!vm_window->image) {
+    if (vm_window->shmid == INVALID_SHM_ID) {
         /* TODO: implement screen_window handling */
         return;
     }
@@ -77,10 +78,11 @@ void fill_tray_bg_and_update(Ghandles *g, struct windowdata *vm_window,
                 vm_window->image_width,
                 vm_window->image_height,
                 24);
-    XShmPutImage(g->display, pixmap, g->context,
-            vm_window->image, 0, 0, 0, 0,
-            vm_window->image_width,
-            vm_window->image_height, 0);
+    put_shm_image(g, pixmap, vm_window,
+        0, 0,
+        vm_window->image_width,
+        vm_window->image_height,
+        0, 0);
     XImage *image = XGetImage(g->display, pixmap, 0, 0, w, h,
             0xFFFFFFFF, ZPixmap);
     /* Use top-left corner pixel color as transparency color */
@@ -231,7 +233,7 @@ void tint_tray_and_update(Ghandles *g, struct windowdata *vm_window,
     uint32_t pixel;
     double h_ignore, l, s_ignore;
 
-    if (!vm_window->image) {
+    if (vm_window->shmid == INVALID_SHM_ID) {
         /* TODO: implement screen_window handling */
         return;
     }
@@ -245,10 +247,11 @@ void tint_tray_and_update(Ghandles *g, struct windowdata *vm_window,
                 vm_window->image_width,
                 vm_window->image_height,
                 24);
-    XShmPutImage(g->display, pixmap, g->context,
-            vm_window->image, 0, 0, 0, 0,
-            vm_window->image_width,
-            vm_window->image_height, 0);
+    put_shm_image(g, pixmap, vm_window,
+        0, 0,
+        vm_window->image_width,
+        vm_window->image_height,
+        0, 0);
     XImage *image = XGetImage(g->display, pixmap, x, y, w, h,
             0xFFFFFFFF, ZPixmap);
     /* tint image */

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -23,6 +23,7 @@
 /* high level documentation is here: https://www.qubes-os.org/doc/gui/ */
 
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <err.h>
@@ -45,11 +46,13 @@
 #include <X11/Xproto.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include <X11/extensions/XShm.h>
 #include <X11/extensions/shmproto.h>
 #include <X11/Xatom.h>
 #include <X11/cursorfont.h>
+#include <xcb/xcb.h>
 #include <X11/Xlib-xcb.h>
+#include <xcb/shm.h>
+#include <xcb/xcb_aux.h>
 #include <libconfig.h>
 #include <libnotify/notify.h>
 #include <assert.h>
@@ -102,12 +105,6 @@ static Ghandles ghandles;
 #endif
 
 #define ignore_result(x) { __typeof__(x) __attribute__((unused)) _ignore=(x);}
-
-/* XShmAttach return value inform only about successful queueing the operation,
- * not its execution. Errors during XShmAttach are reported asynchronously with
- * registered X11 error handler.
- */
-static bool shm_attach_failed = false;
 
 static int (*default_x11_io_error_handler)(Display *dpy);
 static void inter_appviewer_lock(Ghandles *g, int mode);
@@ -234,14 +231,36 @@ static void release_all_shm_no_x11_calls() {
     for (curr = ghandles.wid2windowdata->next;
          curr != ghandles.wid2windowdata; curr = curr->next) {
         struct windowdata *vm_window = curr->data;
-        if (vm_window->image) {
-            vm_window->image = NULL;
-            shmctl(vm_window->shminfo.shmid, IPC_RMID, 0);
-        }
+        if (vm_window->shmid != -1 && vm_window->shmid != INVALID_SHM_ID)
+            shmctl(vm_window->shmid, IPC_RMID, 0);
+        vm_window->shmid = INVALID_SHM_ID;
     }
 
 }
 #endif
+
+
+static void
+qubes_xcb_handler(Ghandles *g, const char *msg, struct windowdata *vm_window,
+                  xcb_generic_error_t *error) {
+    fprintf(stderr,
+        "%s failed for window 0x%lx(remote 0x%lx)\n",
+        msg,
+        vm_window->local_winid,
+        vm_window->remote_winid);
+    shmctl(vm_window->shmid, IPC_RMID, 0);
+    vm_window->shmid = INVALID_SHM_ID;
+    XErrorEvent err = {
+       .type = error->response_type,
+       .display = g->display,
+       .error_code = error->error_code,
+       .resourceid = error->resource_id,
+       .serial = error->full_sequence,
+       .request_code = error->major_code,
+       .minor_code = error->minor_code,
+    };
+    dummy_handler(g->display, &err);
+}
 
 int x11_error_handler(Display * dpy, XErrorEvent * ev)
 {
@@ -264,14 +283,6 @@ int x11_error_handler(Display * dpy, XErrorEvent * ev)
         return 0;
     }
 
-    if (ev->request_code == ghandles.shm_major_opcode
-            && ev->minor_code == X_ShmAttach
-            && ev->error_code == BadAccess) {
-        shm_attach_failed = true;
-        /* shmoverride failed to attach memory region,
-         * handled in handle_mfndump/handle_window_dump */
-        return 0;
-    }
 #ifdef MAKE_X11_ERRORS_FATAL
     /* The exit(1) below will call release_all_mapped_mfns (registerd with
      * atexit(3)), which would try to release window images with XShmDetach. We
@@ -2001,7 +2012,7 @@ static void do_shm_update(Ghandles * g, struct windowdata *vm_window,
         return;
     }
     // now known: untrusted_x and untrusted_y are not negative
-    if (vm_window->image) {
+    if (vm_window->shmid != INVALID_SHM_ID) {
         // image_width and image_height are not negative
         // (checked in handle_mfndump and handle_window_dump)
         x = min(untrusted_x, vm_window->image_width);
@@ -2142,16 +2153,17 @@ static void do_shm_update(Ghandles * g, struct windowdata *vm_window,
         else if (g->trayicon_mode == TRAY_TINT)
             tint_tray_and_update(g, vm_window, x, y, w, h);
     } else {
-        if (vm_window->image) {
-            XShmPutImage(g->display, vm_window->local_winid,
-                    g->context, vm_window->image, x,
-                    y, x, y, w, h, 0);
-        } else if (g->screen_window && g->screen_window->image) {
+        if (vm_window->shmid != INVALID_SHM_ID) {
+            put_shm_image(g, vm_window->local_winid, vm_window, x, y, w, h, x, y);
+        } else if (g->screen_window && g->screen_window->shmid != INVALID_SHM_ID) {
             // vm_window->x+x and vm_window->y+y are the position relative to
             // the screen, while x and y are the position relative to the window
-            XShmPutImage(g->display, vm_window->local_winid,
-                    g->context, g->screen_window->image, vm_window->x+x,
-                    vm_window->y+y, x, y, w, h, 0);
+            put_shm_image(g,
+                          vm_window->local_winid,
+                          g->screen_window,
+                          vm_window->x + x,
+                          vm_window->y + y,
+                          w, h, x, y);
         }
         /* else no window content to update, but still draw a frame (if needed) */
     }
@@ -2435,11 +2447,11 @@ static void handle_create(Ghandles * g, XID window)
     vm_window =
         (struct windowdata *) calloc(1, sizeof(struct windowdata));
     if (!vm_window) {
-        perror("malloc(vm_window in handle_create)");
+        perror("calloc(vm_window in handle_create)");
         exit(1);
     }
+    vm_window->shmid = INVALID_SHM_ID;
     /*
-       because of calloc vm_window->image = 0;
        vm_window->is_mapped = 0;
        vm_window->local_winid = 0;
        vm_window->dest = vm_window->src = vm_window->pix = 0;
@@ -3165,16 +3177,61 @@ static void inter_appviewer_lock(Ghandles *g, int mode)
 /* release shared memory connected with given window */
 static void release_mapped_mfns(Ghandles * g, struct windowdata *vm_window)
 {
-    if (g->invisible || !vm_window->image)
+    if (g->invisible || vm_window->shmid == INVALID_SHM_ID)
         return;
+    if (vm_window->shmid != -1) {
+        inter_appviewer_lock(g, 1);
+        g->shm_args->shmid = vm_window->shmid;
+        xcb_void_cookie_t cookie = check_xcb_void(
+            xcb_shm_detach_checked(g->cb_connection, vm_window->shmseg),
+            "xcb_shm_detach");
+        xcb_aux_sync(g->cb_connection);
+        if (xcb_request_check(g->cb_connection, cookie)) {
+            fputs("SHM detach failed (this is a bug)", stderr);
+            exit(1);
+        }
+        inter_appviewer_lock(g, 0);
+        shmctl(vm_window->shmid, IPC_RMID, 0);
+    }
+    vm_window->shmid = INVALID_SHM_ID;
+}
+
+static void qubes_shm_attach(Ghandles *g, struct windowdata *const vm_window,
+                             struct shm_args_hdr *const shm_args,
+                             const size_t shm_args_len)
+{
+    if (g->invisible)
+        return;
+    // temporary shmid; see shmoverride/README
+    vm_window->shmid = shmget(IPC_PRIVATE, 1, IPC_CREAT | 0700);
+    if (vm_window->shmid < 0) {
+        perror("shmget");
+        exit(1);
+    }
+    vm_window->shmseg = xcb_generate_id(g->cb_connection);
+    shm_args->domid = g->domid;
+    shm_args->shmid = vm_window->shmid;
     inter_appviewer_lock(g, 1);
-    g->shm_args->shmid = vm_window->shminfo.shmid;
-    XShmDetach(g->display, &vm_window->shminfo);
-    XDestroyImage(vm_window->image);
-    XSync(g->display, False);
+    memcpy(g->shm_args, shm_args, shm_args_len);
+    if (shm_args_len < SHM_ARGS_SIZE) {
+        memset(((uint8_t *) g->shm_args) + shm_args_len, 0,
+               SHM_ARGS_SIZE - shm_args_len);
+    }
+    const xcb_void_cookie_t cookie =
+        check_xcb_void(
+            xcb_shm_attach_checked(g->cb_connection, vm_window->shmseg,
+                                   vm_window->shmid, true),
+            "xcb_shm_attach_checked");
+    xcb_aux_sync(g->cb_connection);
+    xcb_generic_error_t *error = xcb_request_check(g->cb_connection, cookie);
+    g->shm_args->shmid = g->cmd_shmid;
     inter_appviewer_lock(g, 0);
-    vm_window->image = NULL;
-    shmctl(vm_window->shminfo.shmid, IPC_RMID, 0);
+    if (error) {
+        qubes_xcb_handler(g, "xcb_shm_attach", vm_window, error);
+        shmctl(vm_window->shmid, IPC_RMID, 0);
+        vm_window->shmid = INVALID_SHM_ID;
+        free(error);
+    }
 }
 
 /* handle VM message: MSG_MFNDUMP
@@ -3235,21 +3292,8 @@ static void handle_mfndump(Ghandles * g, struct windowdata *vm_window)
     shm_args_mfns->off = off;
 
     read_data(g->vchan, (char *) &shm_args_mfns->mfns[0], mfns_len);
-    if (g->invisible)
-        goto out_free_shm_args;
-    vm_window->image =
-        XShmCreateImage(g->display,
-                DefaultVisual(g->display, g->screen), 24,
-                ZPixmap, NULL, &vm_window->shminfo,
-                vm_window->image_width,
-                vm_window->image_height);
-    if (!vm_window->image) {
-        perror("XShmCreateImage");
-        exit(1);
-    }
-    /* the below sanity check must be AFTER XShmCreateImage, it uses vm_window->image */
     if (num_mfn * 4096 <
-        vm_window->image->bytes_per_line * vm_window->image->height +
+        vm_window->image_width * vm_window->image_height * 4 +
         off) {
         fprintf(stderr,
             "handle_mfndump for window 0x%x(remote 0x%x)"
@@ -3258,44 +3302,7 @@ static void handle_mfndump(Ghandles * g, struct windowdata *vm_window)
             (int) vm_window->remote_winid, num_mfn);
         exit(1);
     }
-    // temporary shmid; see shmoverride/README
-    vm_window->shminfo.shmid =
-        shmget(IPC_PRIVATE, 1, IPC_CREAT | 0700);
-    if (vm_window->shminfo.shmid < 0) {
-        perror("shmget");
-        exit(1);
-    }
-    shm_args->shmid = vm_window->shminfo.shmid;
-    shm_args->domid = g->domid;
-    inter_appviewer_lock(g, 1);
-    memcpy(g->shm_args, shm_args, shm_args_len);
-    if (shm_args_len < SHM_ARGS_SIZE) {
-        memset(((uint8_t *) g->shm_args) + shm_args_len, 0,
-               SHM_ARGS_SIZE - shm_args_len);
-    }
-    {
-        static char dummybuf[100];
-        vm_window->shminfo.shmaddr = vm_window->image->data = dummybuf;
-    }
-    vm_window->shminfo.readOnly = True;
-    shm_attach_failed = false;
-    if (!XShmAttach(g->display, &vm_window->shminfo))
-        shm_attach_failed = true;
-    /* shm_attach_failed can be also set by the X11 error handler */
-    XSync(g->display, False);
-    g->shm_args->shmid = g->cmd_shmid;
-    inter_appviewer_lock(g, 0);
-    if (shm_attach_failed) {
-        fprintf(stderr,
-            "XShmAttach failed for window 0x%lx(remote 0x%lx)\n",
-            vm_window->local_winid,
-            vm_window->remote_winid);
-        XDestroyImage(vm_window->image);
-        vm_window->image = NULL;
-        shmctl(vm_window->shminfo.shmid, IPC_RMID, 0);
-    }
-
-out_free_shm_args:
+    qubes_shm_attach(g, vm_window, shm_args, shm_args_len);
     free(shm_args);
 }
 
@@ -3357,7 +3364,6 @@ static void handle_window_dump_body(Ghandles *g, uint32_t wd_type, size_t
 static void handle_window_dump(Ghandles *g, struct windowdata *vm_window,
                                uint32_t untrusted_len) {
     struct msg_window_dump_hdr untrusted_wd_hdr;
-    static char dummybuf[100];
     struct shm_args_hdr *shm_args = NULL;
     size_t shm_args_len = 0, img_data_size = 0;
 
@@ -3390,33 +3396,14 @@ static void handle_window_dump(Ghandles *g, struct windowdata *vm_window,
     vm_window->image_height = untrusted_wd_hdr.height;
     //VERIFY(untrusted_wd_hdr.bpp == 24);
 
+    vm_window->shmid = -1;
+
     handle_window_dump_body(g, wd_type, untrusted_wd_body_len, &img_data_size,
                             &shm_args, &shm_args_len);
 
-    if (g->invisible)
-        return;
-
-    // temporary shmid; see shmoverride/README
-    vm_window->shminfo.shmid =
-        shmget(IPC_PRIVATE, 1, IPC_CREAT | 0700);
-    if (vm_window->shminfo.shmid < 0) {
-        perror("shmget failed");
-        exit(1);
-    }
-
-    vm_window->image =
-        XShmCreateImage(g->display,
-                DefaultVisual(g->display, g->screen), 24,
-                ZPixmap, NULL, &vm_window->shminfo,
-                vm_window->image_width,
-                vm_window->image_height);
-    if (!vm_window->image) {
-        perror("XShmCreateImage");
-        exit(1);
-    }
-    /* the below sanity check must be AFTER XShmCreateImage, it uses vm_window->image */
-    if (img_data_size < (size_t) (vm_window->image->bytes_per_line *
-                                  vm_window->image->height)) {
+    if (img_data_size < (size_t) (vm_window->image_width *
+                                  vm_window->image_height *
+                                  4)) {
         fprintf(stderr,
             "handle_window_dump: got too small image data size (%zu)"
             " for window 0x%lx (remote 0x%lx)\n",
@@ -3424,32 +3411,7 @@ static void handle_window_dump(Ghandles *g, struct windowdata *vm_window,
         exit(1);
     }
 
-    shm_args->domid = g->domid;
-    shm_args->shmid = vm_window->shminfo.shmid;
-    inter_appviewer_lock(g, 1);
-    memcpy(g->shm_args, shm_args, shm_args_len);
-    if (shm_args_len < SHM_ARGS_SIZE) {
-        memset(((uint8_t *) g->shm_args) + shm_args_len, 0,
-               SHM_ARGS_SIZE - shm_args_len);
-    }
-    vm_window->shminfo.shmaddr = vm_window->image->data = dummybuf;
-    vm_window->shminfo.readOnly = True;
-    shm_attach_failed = false;
-    if (!XShmAttach(g->display, &vm_window->shminfo))
-        shm_attach_failed = true;
-    /* shm_attach_failed can be also set by the X11 error handler */
-    XSync(g->display, False);
-    g->shm_args->shmid = g->cmd_shmid;
-    inter_appviewer_lock(g, 0);
-    if (shm_attach_failed) {
-        fprintf(stderr,
-            "XShmAttach failed for window 0x%lx(remote 0x%lx)\n",
-            vm_window->local_winid,
-            vm_window->remote_winid);
-        XDestroyImage(vm_window->image);
-        vm_window->image = NULL;
-        shmctl(vm_window->shminfo.shmid, IPC_RMID, 0);
-    }
+    qubes_shm_attach(g, vm_window, shm_args, shm_args_len);
     free(shm_args);
 }
 

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -229,6 +229,7 @@ struct _global_handles {
     char *screensaver_names[MAX_SCREENSAVER_NAMES]; /* WM_CLASS names for windows detected as screensavers */
     Cursor *cursors;  /* preloaded cursors (using XCreateFontCursor) */
     xcb_connection_t *cb_connection; /**< XCB connection */
+    xcb_gcontext_t gc; /**< XCB graphics context */
     int work_x, work_y, work_width, work_height;  /* do not allow a window to go beyond these bounds */
     Atom qubes_label, qubes_label_color, qubes_vmname, qubes_vmwindowid, net_wm_icon;
     bool in_dom0; /* true if we are in dom0, otherwise false */

--- a/include/util.h
+++ b/include/util.h
@@ -1,5 +1,19 @@
+#ifndef QUBES_GUI_UTIL_H
+#define QUBES_GUI_UTIL_H QUBES_GUI_UTIL_H
 /* Get the size of an array.  Error out on pointers. */
 #define QUBES_ARRAY_SIZE(x) (0 * sizeof(struct { \
     int tried_to_compute_number_of_array_elements_in_a_pointer: \
         1 - 2*__builtin_types_compatible_p(__typeof__(x), __typeof__(&((x)[0]))); \
     }) + sizeof(x)/sizeof((x)[0]))
+
+/* Exit if an XCB request fails */
+static inline xcb_void_cookie_t check_xcb_void(
+        xcb_void_cookie_t cookie,
+        const char *msg) {
+    if (!cookie.sequence) {
+        perror(msg);
+        exit(1);
+    }
+    return cookie;
+}
+#endif

--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -45,9 +45,11 @@ Requires:   socat
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  pulseaudio-libs-devel
+BuildRequires:	pkgconfig(x11)
 BuildRequires:	pkgconfig(x11-xcb)
 BuildRequires:	pkgconfig(xcb)
-BuildRequires:	libXext-devel
+BuildRequires:	pkgconfig(xcb-aux)
+BuildRequires:	pkgconfig(xcb-shm)
 BuildRequires:	libXrandr-devel
 BuildRequires:	libconfig-devel
 BuildRequires:	libpng-devel

--- a/shmoverride/README
+++ b/shmoverride/README
@@ -1,6 +1,6 @@
 	The shmoverride.so library is supposed to be loaded by Xorg server
 (via LD_PRELOAD). It intercepts the shmat, shmdt and shmctl glibc calls, so
-that when XShmAttach is called (by qubes_guid) with a "magic" argument, then 
+that when xcb_shm_attach is called (by qubes_guid) with a "magic" argument, then
 instead of attaching regular shared memory, memory from a foreign domain is
 attached via xc_map_foreign_pages. This mechanism is used to map composition
 buffers from a foreign domain into Xorg server.
@@ -8,19 +8,19 @@ buffers from a foreign domain into Xorg server.
 (cmd_pages) and writes its shmid to /var/run/qubes/shm.id.$DISPLAY. All
 instances of qubes_guid map this segment and communicate with shmoverride.so
 code by setting its fields. When qubes_guid wants its
-XShmAttach(...synth_shmid...) call to be handled by shmoverride.so, it sets the 
-"shmid" field in the cmd_pages shared memory segment to synth_shmid just
-before calling XShmAttach. Function shmat (implemented in shmoverride.so)
+xcb_shm_attach(...synth_shmid...) call to be handled by shmoverride.so, it sets
+the "shmid" field in the cmd_pages shared memory segment to synth_shmid just
+before calling xcb_shm_attach. Function shmat (implemented in shmoverride.so)
 checks whether first argument of shmat is equal to cmd_pages->shmid, and if
 so, calls xc_map_foreign_pages properly (if not, just calls real shmat).
 Other fields in cmd_pages describe which frames are supposed to be mapped 
 and from which domain.
 	Somewhat unfortunately, the Xorg server tracks the already attached shmids.
 Therefore, it is not possible to pass the same "magic" value of synth_shmid
-to XShmAttach(...synth_shmid...). Before each XShmAttach, qubes_guid creates
-a corresponding real shared memory segment, sets cmd_pages->shmid to it, and
-then executes XShmAttach. This segment is destroyed when the corresponding
-backing memory for the composition buffer is released, such as when the window
-is resized or closed. Keeping this additional otherwise-unused segment around
-for the whole life of the actual inter-domain shared-memory being used is
-necessary in order to prevent X from getting confused by shmid reuse.
+to xcb_shm_attach(...synth_shmid...). Before each xcb_shm_attach, qubes-guid
+creates a corresponding real shared memory segment, sets cmd_pages->shmid to
+it, and then executes xcb_shm_attach. This segment is destroyed when the
+corresponding backing memory for the composition buffer is released, such as
+when the window is resized or closed. Keeping this additional otherwise-unused
+segment around for the whole life of the actual inter-domain shared-memory being
+used is necessary in order to prevent X from getting confused by shmid reuse.


### PR DESCRIPTION
Xlib does not support file descriptor passing or dma-bufs.  The GUI daemon does not currently use either of these, but it will in the future.  Switching from Xlib to XCB is a necessary first step in that direction.

This is a subset of #65: it includes the parts that can work without needing any changes to the X server or kernel.