### PR TITLE
force_on_screen(): fix calculations

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -1558,7 +1558,7 @@ static void set_override_redirect(Ghandles * g, struct windowdata *vm_window,
 		return;
 	}
 
-	avail = (uint64_t) g->root_width * (uint64_t) g->root_height;
+	avail = (uint64_t) g->work_width * (uint64_t) g->work_height;
 	desired = (uint64_t) vm_window->width * (uint64_t) vm_window->height;
 
 	if (g->override_redirect_protection && req_override_redirect &&
@@ -1569,12 +1569,12 @@ static void set_override_redirect(Ghandles * g, struct windowdata *vm_window,
 			fprintf(stderr,
 				"%s unset override_redirect for "
 				"local 0x%x remote 0x%x, "
-				"window w=%u h=%u, root w=%d h=%d\n",
+				"window w=%u h=%u, work w=%d h=%d\n",
 				__func__,
 				(unsigned) vm_window->local_winid,
 				(unsigned) vm_window->remote_winid,
 				vm_window->width, vm_window->height,
-				g->root_width, g->root_height);
+				g->work_width, g->work_height);
 
 		/* Show a message to the user, but do this only once. */
 		if (!warning_shown) {

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -164,7 +164,7 @@ struct _global_handles {
     Atom wm_state_demands_attention; /* Atom: _NET_WM_STATE_DEMANDS_ATTENTION */
     Atom wm_state_hidden;    /* Atom: _NET_WM_STATE_HIDDEN */
     Atom wm_workarea;      /* Atom: _NET_WORKAREA */
-    Atom wm_current_desktop;      /* Atom: _NET_CURRENT_DESKTOP */
+    Atom net_current_desktop;     /* Atom: _NET_CURRENT_DESKTOP */
     Atom frame_extents; /* Atom: _NET_FRAME_EXTENTS */
     Atom wm_state_maximized_vert; /* Atom: _NET_WM_STATE_MAXIMIZED_VERT */
     Atom wm_state_maximized_horz; /* Atom: _NET_WM_STATE_MAXIMIZED_HORZ */


### PR DESCRIPTION
Instead of trying to check for offscreen windows while sanitizing window
positions, return early in the case of offscreen windows, and then
sanitize x, y, width, height, x + width, and y + height separately.
This takes more code, but the new code is much, *much* simpler and
easier to understand.

Fixes QubesOS/qubes-issues#6518.