### PR TITLE
Check if a window is referenced by another one before destroying it

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -2704,8 +2704,12 @@ static void handle_map(Ghandles * g, struct windowdata *vm_window)
         vm_window->transient_for = transdata;
         XSetTransientForHint(g->display, vm_window->local_winid,
                      transdata->local_winid);
-    } else
+    } else {
+        if (vm_window->transient_for)
+            XDeleteProperty(g->display, vm_window->local_winid,
+                    XA_WM_TRANSIENT_FOR);
         vm_window->transient_for = NULL;
+    }
 
     set_override_redirect(g, vm_window, !!(untrusted_txt.override_redirect));
     attr.override_redirect = vm_window->override_redirect;

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -2201,6 +2201,36 @@ static void handle_create(Ghandles * g, XID window)
         moveresize_vm_window(g, vm_window);
 }
 
+/* Check if window (to be destroyed) is not used anywhere. If it is, act
+ * accordingly:
+ *  - if it is a parent for some - terminate abruptly (children should be
+ *    destroyed earlier)
+ *  - if it is a set as transient_for - clear that hint
+ */
+static void check_window_references(Ghandles * g, struct windowdata *vm_window)
+{
+    struct genlist *iter;
+
+    list_for_each(iter, g->wid2windowdata) {
+        struct windowdata *iter_window = iter->data;
+        if (iter_window->parent == vm_window) {
+            fprintf(stderr, "Window 0x%x is still a parent for 0x%x, "
+                    "but VM tried to destroy it\n",
+                   (int)vm_window->local_winid, (int)iter_window->local_winid);
+            fprintf(stderr, "Aborting\n");
+            exit(1);
+        }
+        if (iter_window->transient_for == vm_window) {
+            fprintf(stderr, "Window 0x%x is still set as transient_for "
+                    "for a 0x%x window, but VM tried to destroy it\n",
+                    (int)vm_window->local_winid, (int)iter_window->local_winid);
+            XDeleteProperty(g->display, vm_window->local_winid,
+                    XA_WM_TRANSIENT_FOR);
+            iter_window->transient_for = NULL;
+        }
+    }
+}
+
 /* handle VM message: MSG_DESTROY
  * destroy window locally, as requested */
 static void handle_destroy(Ghandles * g, struct genlist *l)
@@ -2210,6 +2240,9 @@ static void handle_destroy(Ghandles * g, struct genlist *l)
     g->windows_count--;
     if (vm_window == g->last_input_window)
         g->last_input_window = NULL;
+    /* check if this window is referenced anywhere */
+    check_window_references(g, vm_window);
+    /* then destroy */
     XDestroyWindow(g->display, vm_window->local_winid);
     if (g->log_level > 0)
         fprintf(stderr, " XDestroyWindow 0x%x\n",

--- a/include/list.h
+++ b/include/list.h
@@ -30,3 +30,6 @@ struct genlist *list_new(void);
 struct genlist *list_lookup(struct genlist *l, long key);
 struct genlist *list_insert(struct genlist *l, long key, void *data);
 void list_remove(struct genlist *);
+
+#define list_for_each(iter, list) \
+    for (iter = (list)->next; iter != (list); iter = iter->next)


### PR DESCRIPTION
There can be two types of relations:
- `parent`: in this case agent must destroy children windows first - if
 that isn't the case, terminate abruptly
- `transient_for`: in that case clear the reference (both in local
 structure and in the X server)