### PR TITLE
Obtain an XCB connection handle

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends:
  libvchan-xen-dev,
  python3-dev,
  libpulse-dev,
- libxt-dev,
  libxext-dev,
  libxrandr-dev,
  libxcb1-dev,

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,8 @@ Build-Depends:
  libxt-dev,
  libxext-dev,
  libxrandr-dev,
+ libxcb1-dev,
+ libx11-xcb-dev,
  libconfig-dev,
  libpng-dev,
  libnotify-dev,

--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -22,7 +22,7 @@
 MAKEFLAGS := -rR
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 CC=gcc
-pkgs := x11 xext glib-2.0 $(VCHAN_PKG) libpng libnotify libconfig
+pkgs := x11 xext x11-xcb xcb glib-2.0 $(VCHAN_PKG) libpng libnotify libconfig
 objs := xside.o png.o trayicon.o ../gui-common/double-buffer.o ../gui-common/txrx-vchan.o \
 	../gui-common/error.o list.o
 extra_cflags := -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC \

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -44,7 +44,6 @@
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/Xlib.h>
-#include <X11/Intrinsic.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XShm.h>
 #include <X11/extensions/shmproto.h>

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -50,6 +50,7 @@
 #include <X11/extensions/shmproto.h>
 #include <X11/Xatom.h>
 #include <X11/cursorfont.h>
+#include <X11/Xlib-xcb.h>
 #include <libconfig.h>
 #include <libnotify/notify.h>
 #include <assert.h>
@@ -552,6 +553,10 @@ static void mkghandles(Ghandles * g)
     g->display = XOpenDisplay(NULL);
     if (!g->display) {
         perror("XOpenDisplay");
+        exit(1);
+    }
+    if (!(g->cb_connection = XGetXCBConnection(g->display))) {
+        perror("XGetXCBConnection");
         exit(1);
     }
     g->screen = DefaultScreen(g->display);

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -84,6 +84,8 @@
 #include <libvchan.h>
 #include <X11/Xlib.h>
 #include <X11/extensions/XShm.h>
+#include <xcb/xcb.h>
+#include <xcb/xproto.h>
 
 #define QUBES_POLICY_EVAL_SIMPLE_SOCKET ("/etc/qubes-rpc/" QUBES_SERVICE_EVAL_SIMPLE)
 #define QREXEC_PRELUDE_CLIPBOARD_PASTE (QUBES_SERVICE_EVAL_SIMPLE "+" QUBES_SERVICE_CLIPBOARD_PASTE " dom0 keyword adminvm")
@@ -223,6 +225,7 @@ struct _global_handles {
     bool disable_override_redirect; /* Disable “override redirect” windows */
     char *screensaver_names[MAX_SCREENSAVER_NAMES]; /* WM_CLASS names for windows detected as screensavers */
     Cursor *cursors;  /* preloaded cursors (using XCreateFontCursor) */
+    xcb_connection_t *cb_connection; /**< XCB connection */
     int work_x, work_y, work_width, work_height;  /* do not allow a window to go beyond these bounds */
     Atom qubes_label, qubes_label_color, qubes_vmname, qubes_vmwindowid, net_wm_icon;
     bool in_dom0; /* true if we are in dom0, otherwise false */

--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -46,7 +46,6 @@ BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  pulseaudio-libs-devel
 BuildRequires:	pkgconfig(x11-xcb)
 BuildRequires:	pkgconfig(xcb)
-BuildRequires:	libXt-devel
 BuildRequires:	libXext-devel
 BuildRequires:	libXrandr-devel
 BuildRequires:	libconfig-devel

--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -44,6 +44,8 @@ Requires:   socat
 
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  pulseaudio-libs-devel
+BuildRequires:	pkgconfig(x11-xcb)
+BuildRequires:	pkgconfig(xcb)
 BuildRequires:	libXt-devel
 BuildRequires:	libXext-devel
 BuildRequires:	libXrandr-devel


### PR DESCRIPTION
This is necessary for all future XCB operations, and allows using XCB
instead of Xlib in the GUI daemon.  Complete conversion to XCB is not a
goal at this time, but XCB has several advantages over Xlib, so having
it be an option is desirable.