### PR TITLE
Use -fvisibility=hidden for building C

### DIFF
--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -26,12 +26,12 @@ pkgs := x11 xext x11-xcb xcb glib-2.0 $(VCHAN_PKG) libpng libnotify libconfig
 objs := xside.o png.o trayicon.o ../gui-common/double-buffer.o ../gui-common/txrx-vchan.o \
 	../gui-common/error.o list.o
 extra_cflags := -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC \
-		$(shell pkg-config --cflags $(pkgs))
+		$(shell pkg-config --cflags $(pkgs)) -fvisibility=hidden
 LDLIBS := $(shell pkg-config --libs $(pkgs))
 all: qubes-guid # qubes-guid.1
 vpath %.c ../common
 qubes-guid: $(objs)
-	$(CC) -g -pie -o qubes-guid $(objs) -Wall -lm $(LDLIBS) $(LDFLAGS)
+	$(CC) -g -pie -o qubes-guid $(objs) -Wall -lm $(LDLIBS) $(LDFLAGS) -Wl,-Bsymbolic
 
 qubes-guid.1: qubes-guid
 	LC_ALL=C help2man --version-string=`cat ../version` --no-info --name="Qubes GUI daemon" ./qubes-guid  > qubes-guid.1

--- a/shmoverride/Makefile
+++ b/shmoverride/Makefile
@@ -30,7 +30,7 @@ LIBDIR ?= /usr/lib64
 extra_cflags := -g -O2 -I../include/ -fPIC -Wall -Wextra -Werror \
 		-DBACKEND_VMM_$(BACKEND_VMM) \
 		-DSHMOVERRIDE_LIB_PATH=\"$(LIBDIR)/qubes-gui-daemon/shmoverride.so\" \
-		-I../include
+		-I../include -fvisibility=hidden
 CC=gcc
 
 all: shmoverride.so X-wrapper-qubes

--- a/shmoverride/shmoverride.c
+++ b/shmoverride/shmoverride.c
@@ -120,6 +120,7 @@ static uint8_t *shmat_grant_refs(struct shm_args_hdr *shm_args,
     return map;
 }
 
+__attribute__((visibility("default")))
 void *shmat(int shmid, const void *shmaddr, int shmflg)
 {
     uint8_t *fakeaddr = NULL;
@@ -163,6 +164,7 @@ static int shmdt_grant_refs(void *map, struct info *info) {
     return xengnttab_unmap(xgt, map, info->u.grant.count);
 }
 
+__attribute__((visibility("default")))
 int shmdt(const void *shmaddr)
 {
     void *addr = (void *) shmaddr; // drop const qualifier
@@ -204,6 +206,7 @@ static size_t shm_segsz_grant_refs(struct shm_args_hdr *shm_args) {
     return shm_args_grant->count * XC_PAGE_SIZE;
 }
 
+__attribute__((visibility("default")))
 int shmctl(int shmid, int cmd, struct shmid_ds *buf)
 {
     size_t segsz = 0;


### PR DESCRIPTION
This allows for more compiler optimizations and ensures that shmoverride
does not export more symbols than it should.