### PR TITLE
Unset fullscreen when a window leaves focus

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -1882,6 +1882,9 @@ static void process_xevent_focus(Ghandles * g, const XFocusChangeEvent * ev)
         hdr.window = 0;
         write_message(g->vchan, hdr, keys);
     } else {
+        if (g->log_level > 0)
+            fprintf(stderr, "Clearing fullscreen flag of window 0x%x as it no longer has focus\n",
+                    (int)ev->window);
         struct msg_window_flags flags = {
             .flags_set = 0,
             .flags_unset = WINDOW_FLAG_FULLSCREEN,
@@ -2128,6 +2131,9 @@ static void process_xevent_propertynotify(Ghandles *g, const XPropertyEvent *con
                 return;
             g->active_window = active;
             CHECK_NONMANAGED_WINDOW(g, old_active);
+            if (g->log_level > 0)
+                fprintf(stderr, "Clearing fullscreen flag of window 0x%x as it is no longer active\n",
+                        (int)old_active);
             struct msg_window_flags flags = {
                 .flags_set = 0,
                 .flags_unset = WINDOW_FLAG_FULLSCREEN,

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -561,6 +561,7 @@ static void intern_global_atoms(Ghandles *const g) {
         { &g->qubes_vmwindowid, "_QUBES_VMWINDOWID" },
         { &g->net_wm_icon, "_NET_WM_ICON" },
         { &g->net_current_desktop, "_NET_CURRENT_DESKTOP" },
+        { &g->net_active_window, "_NET_ACTIVE_WINDOW" },
         { &g->wm_user_time_window, "_NET_WM_USER_TIME_WINDOW" },
         { &g->wm_user_time, "_NET_WM_USER_TIME" },
         { &g->wmDeleteMessage, "WM_DELETE_WINDOW" },

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -233,6 +233,7 @@ struct _global_handles {
     Atom qubes_label, qubes_label_color, qubes_vmname, qubes_vmwindowid, net_wm_icon;
     bool in_dom0; /* true if we are in dom0, otherwise false */
     Atom net_supported;
+    Window active_window; /* Active window */
 };
 
 typedef struct _global_handles Ghandles;

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -233,7 +233,6 @@ struct _global_handles {
     Atom qubes_label, qubes_label_color, qubes_vmname, qubes_vmwindowid, net_wm_icon;
     bool in_dom0; /* true if we are in dom0, otherwise false */
     Atom net_supported;
-    Window active_window; /* Active window */
 };
 
 typedef struct _global_handles Ghandles;

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -165,6 +165,7 @@ struct _global_handles {
     Atom wm_state_hidden;    /* Atom: _NET_WM_STATE_HIDDEN */
     Atom wm_workarea;      /* Atom: _NET_WORKAREA */
     Atom net_current_desktop;     /* Atom: _NET_CURRENT_DESKTOP */
+    Atom net_active_window;       /* Atom: _NET_ACTIVE_WINDOW */
     Atom frame_extents; /* Atom: _NET_FRAME_EXTENTS */
     Atom wm_state_maximized_vert; /* Atom: _NET_WM_STATE_MAXIMIZED_VERT */
     Atom wm_state_maximized_horz; /* Atom: _NET_WM_STATE_MAXIMIZED_HORZ */


### PR DESCRIPTION
This is a security measure, to ensure that a window can be forced out of the fullscreen state.
