### PR TITLE
Fix non-refreshed tray icons

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -2368,7 +2368,7 @@ static void handle_shmimage(Ghandles * g, struct windowdata *vm_window)
     struct msg_shmimage untrusted_mx;
 
     read_struct(g->vchan, untrusted_mx);
-    if (!vm_window->is_mapped)
+    if (!vm_window->is_mapped && !vm_window->is_docked)
         return;
     if (g->log_level >= 2) {
         fprintf(stderr, "shmimage for 0x%x(remote 0x%x), x: %d, y: %d, w: %d, h: %d\n",

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -354,6 +354,7 @@ static Window mkwindow(Ghandles * g, struct windowdata *vm_window)
     else
         parent = g->root_win;
     attr.override_redirect = vm_window->override_redirect;
+    attr.background_pixel = WhitePixel(g->display, DefaultScreen(g->display));
     child_win = XCreateWindow(g->display, parent,
                     vm_window->x, vm_window->y,
                     vm_window->width,
@@ -361,7 +362,7 @@ static Window mkwindow(Ghandles * g, struct windowdata *vm_window)
                     CopyFromParent,
                     CopyFromParent,
                     CopyFromParent,
-                    CWOverrideRedirect, &attr);
+                    CWOverrideRedirect | CWBackPixel, &attr);
     /* pass my size hints to the window manager, along with window
        and icon names */
     (void) XSetStandardProperties(g->display, child_win,

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -3055,9 +3055,15 @@ static void handle_dock(Ghandles * g, struct windowdata *vm_window)
         return;
     }
     if (vm_window->override_redirect) {
-        fprintf(stderr, "cannot dock override-redirect window 0x%x\n",
+        XSetWindowAttributes attr;
+        fprintf(stderr, "docking an override-redirect window 0x%x - "
+                "clearing override-redirect\n",
                 (int) vm_window->local_winid);
-        return;
+        /* changing directly is safe, because window is not mapped here yet */
+        attr.override_redirect = vm_window->override_redirect;
+        XChangeWindowAttributes(g->display, vm_window->local_winid,
+                CWOverrideRedirect, &attr);
+        vm_window->override_redirect = 0;
     }
     if (vm_window->parent) {
         fprintf(stderr, "cannot dock non-top level window 0x%x\n",


### PR DESCRIPTION
Force refreshing tray icon just after docking it

Fixes QubesOS/qubes-issues#6856