### PR TITLE
Disable subwindows by default

### DIFF
--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -30,7 +30,24 @@ global: {
   #
   # override_redirect_protection = true;
 
-  # Allow UTF-8 title characters
+  # Allow or disable the use of the override_redirect flag.  You can set this to
+  # "disabled" to ignore this flag and render as if the flag were not set.
+  # The default is "allow", as "disabled" will break many applications.
+  # Qubes OS already provides protection against serious abuse of
+  # override_redirect windows.
+  # override_redirect = "allow";
+
+  # Forbid or allow X11 subwindows (windows with a parent other than the root
+  # window).  None of the GUI agents included with Qubes OS create such
+  # windows, and future versions of the GUI agent also will not create them.
+  # Furthermore, subwindows were involved in one of the exploits for QSB#072.
+  # Therefore, the default is to disable subwindows.  Applications that *use*
+  # subwindows are not affected and will still work.
+  # subwindows = "forbid";
+
+  # Allow non-ASCII UTF-8 title characters.  This increases the risk of a
+  # vulnerability in the text rendering stack being exploited, so the default is
+  # false.
   #
   # allow_utf8_titles = false;
 

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -232,6 +232,7 @@ struct _global_handles {
     Atom qubes_label, qubes_label_color, qubes_vmname, qubes_vmwindowid, net_wm_icon;
     bool in_dom0; /* true if we are in dom0, otherwise false */
     Atom net_supported;
+    bool permit_subwindows : 1; /* Permit subwindows */
 };
 
 typedef struct _global_handles Ghandles;


### PR DESCRIPTION
The default GUI agent never creates them, and they are extra attack surface.  For instance, they are involved in one of the exploits for QSB#072.