### PR TITLE
Disable child windows entirely

### DIFF
--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -112,8 +112,6 @@ struct windowdata {
     XID remote_winid;    /* window id on VM side */
     Window local_winid;    /* window id on X side */
     Window local_frame_winid; /* window id of frame window created by window manager */
-    int children_count;
-    struct windowdata *parent;    /* parent window */
     struct windowdata *transient_for;    /* transient_for hint for WM, see http://tronche.com/gui/x/icccm/sec-4.html#WM_TRANSIENT_FOR */
     int override_redirect;    /* see http://tronche.com/gui/x/xlib/window/attributes/override-redirect.html */
     XShmSegmentInfo shminfo;    /* temporary shmid; see shmoverride/README */


### PR DESCRIPTION
X11 child windows are not capable enough to implement Wayland subsurfaces, so Wayland subsurfaces will need to be software composited anyway.  This leaves child windows with no uses, so ban them.
