### PR TITLE
Flush after emergency move

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -1764,6 +1764,7 @@ static void process_xevent_configure(Ghandles * g, const XConfigureEvent * ev)
                     "0x%lx(0x%lx) outside of allowed area, moving it back\n",
                     vm_window->local_winid, vm_window->remote_winid);
         moveresize_vm_window(g, vm_window, false);
+        XFlush(g->display);
     }
 
 // if AppVM has not unacknowledged previous resize msg, do not send another one


### PR DESCRIPTION
This ensures that the X server receives the message immediately without any delay.

Not tested, but should be a trivial change.