### PR TITLE
Remove windows_count from Ghandles

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -2514,7 +2514,6 @@ static void handle_destroy(Ghandles * g, struct genlist *l)
 {
     struct genlist *l2;
     struct windowdata *vm_window = l->data;
-    g->windows_count--;
     /* check if this window is referenced anywhere */
     check_window_references(g, vm_window);
     /* then destroy */

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -199,7 +199,6 @@ struct _global_handles {
     int clipboard_requested;    /* if clippoard content was requested by dom0 */
     Time clipboard_xevent_time;  /* timestamp of keypress which triggered last copy/paste */
     Window time_win; /* Window to set _NET_WM_USER_TIME on */
-    int windows_count;    /* created window count */
     /* signal was caught */
     int volatile reload_requested;
     pid_t pulseaudio_pid;


### PR DESCRIPTION
Its only purpose was to cause undefined behavior (integer overflow)
after destroying 2147483649 windows.