### PR TITLE
Update pacat-simple-vchan.c

### DIFF
--- a/pulse/pacat-simple-vchan.c
+++ b/pulse/pacat-simple-vchan.c
@@ -617,7 +617,7 @@ fail:
 static int create_pidfile(int domid, char **pidfile_path, int *pidfile_fd)
 {
     int fd, ret;
-    char pid_s[16];
+    char pid_s[16] = {};
 
     if (asprintf(pidfile_path, PACAT_PIDFILE_PATH_TPL, domid) < 0) {
         pacat_log("Failed to construct pidfile path, out of memory?");
@@ -738,7 +738,8 @@ static void control_socket_callback(pa_mainloop_api *UNUSED(a),
 
 static int setup_control(struct userdata *u) {
     int socket_fd = -1;
-    struct sockaddr_un addr;
+    /* better safe than sorry - zero initialize the buffer */
+    struct sockaddr_un addr = {};
 
     socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (socket_fd == -1) {
@@ -752,6 +753,9 @@ static int setup_control(struct userdata *u) {
         pacat_log("VM name too long");
         goto fail;
     }
+    /* without this line, the bind() fails in many linux versions
+       with Invalid Argument, and mic cannot attach */
+    addr.sun_family = AF_UNIX;
 
     /* ignore result */
     unlink(addr.sun_path);

--- a/pulse/pacat-simple-vchan.c
+++ b/pulse/pacat-simple-vchan.c
@@ -617,7 +617,7 @@ fail:
 static int create_pidfile(int domid, char **pidfile_path, int *pidfile_fd)
 {
     int fd, ret;
-    char pid_s[16] = {};
+    char pid_s[16] = { 0 };
 
     if (asprintf(pidfile_path, PACAT_PIDFILE_PATH_TPL, domid) < 0) {
         pacat_log("Failed to construct pidfile path, out of memory?");
@@ -739,7 +739,7 @@ static void control_socket_callback(pa_mainloop_api *UNUSED(a),
 static int setup_control(struct userdata *u) {
     int socket_fd = -1;
     /* better safe than sorry - zero initialize the buffer */
-    struct sockaddr_un addr = {};
+    struct sockaddr_un addr = { 0 };
 
     socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (socket_fd == -1) {


### PR DESCRIPTION
fix problem that broke the creation of the unix domain socket

The problem is mentioned in many places:
https://forum.qubes-os.org/t/r4-1-audio-does-not-go-from-appvm-to-dom0-in-default-installation/9532/14
https://forum.qubes-os.org/t/setting-up-an-audio-vm/5491/27

DISCLAIMER: not tested, I do not have a good testing environment
