### PR TITLE
Implement GUI protocol 1.4

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -744,7 +744,8 @@ void reload(Ghandles * g) {
 
     g->screen = DefaultScreen(g->display);
     g->root_win = RootWindow(g->display, g->screen);
-    XGetWindowAttributes(g->display, g->root_win, &attr);
+    if (!XGetWindowAttributes(g->display, g->root_win, &attr))
+        errx(1, "Cannot query root window attributes!");
     g->root_width = _VIRTUALX(attr.width);
     g->root_height = attr.height;
     update_work_area(g);
@@ -3600,7 +3601,8 @@ static void send_xconf(Ghandles * g)
 {
     struct msg_xconf xconf;
     XWindowAttributes attr;
-    XGetWindowAttributes(g->display, g->root_win, &attr);
+    if (!XGetWindowAttributes(g->display, g->root_win, &attr))
+        errx(1, "Cannot query root window attributes!");
     xconf.w = _VIRTUALX(attr.width);
     xconf.h = attr.height;
     xconf.depth = attr.depth;

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -3625,24 +3625,27 @@ static void get_protocol_version(Ghandles * g)
         g->agent_version = version_major << 16 | version_minor;
         return;
     }
-    if (version_major < PROTOCOL_VERSION_MAJOR)
+    if (version_major < PROTOCOL_VERSION_MAJOR) {
         /* agent is too old */
-        snprintf(message, sizeof message, "%s %s \""
+        if ((unsigned)snprintf(message, sizeof message, "%s %s \""
                 "The GUI agent that runs in the VM '%s' implements outdated protocol (%d:%d), and must be updated.\n\n"
                 "To start and access the VM or template without GUI virtualization, use the following commands:\n"
                 "qvm-start --no-guid vmname\n"
                 "qvm-console-dispvm vmname\"",
                 g->use_kdialog ? KDIALOG_PATH : ZENITY_PATH,
                 g->use_kdialog ? "--sorry" : "--error --text ",
-                g->vmname, version_major, version_minor);
-    else
+                g->vmname, version_major, version_minor) >= sizeof message)
+            abort();
+    } else {
         /* agent is too new */
-        snprintf(message, sizeof message, "%s %s \""
+        if ((unsigned)snprintf(message, sizeof message, "%s %s \""
                 "The Dom0 GUI daemon do not support protocol version %d:%d, requested by the VM '%s'.\n"
                 "To update Dom0, use 'qubes-dom0-update' command or do it via qubes-manager\"",
                 g->use_kdialog ? KDIALOG_PATH : ZENITY_PATH,
                 g->use_kdialog ? "--sorry" : "--error --text ",
-                version_major, version_minor, g->vmname);
+                version_major, version_minor, g->vmname) >= sizeof message)
+            abort();
+    }
     ignore_result(system(message));
     exit(1);
 }

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -73,7 +73,7 @@
 #define PROTOCOL_VERSION(x, y) ((x) << 16 | (y))
 
 #if !(PROTOCOL_VERSION_MAJOR == QUBES_GUID_PROTOCOL_VERSION_MAJOR && \
-      PROTOCOL_VERSION_MINOR <= QUBES_GUID_PROTOCOL_VERSION_MINOR)
+      3 <= QUBES_GUID_PROTOCOL_VERSION_MINOR)
 #  error Incompatible qubes-gui-protocol.h.
 #endif
 

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -181,7 +181,8 @@ struct _global_handles {
     char vmname[32];    /* name of VM */
     int domid;        /* Xen domain id (GUI) */
     int target_domid;        /* Xen domain id (VM) - can differ from domid when GUI is stubdom */
-    uint32_t agent_version;  /* gui-agent (protocol) version */
+    uint32_t protocol_version;  /* Negotiated protocol version.  Must be uint32_t
+                                   as it is used as a protocol message. */
     char *cmdline_color;    /* color of frame */
     uint32_t label_color_rgb; /* color of the frame in RGB */
     char *cmdline_icon;    /* icon hint for WM */


### PR DESCRIPTION
This allows bidirectional protocol negotiation, which means that the
agent can be newer than the daemon.

The daemon must be upgraded to support protocol 1.4 first.  Afterwards,
agents and daemons can be independently upgraded.