### PR TITLE
Release MFNs for unmapped windows as well

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -3503,6 +3503,7 @@ static void handle_message(Ghandles * g)
             break;
         vm_window->is_mapped = 0;
         (void) XUnmapWindow(g->display, vm_window->local_winid);
+        release_mapped_mfns(g, vm_window);
         break;
     case MSG_CONFIGURE:
         handle_configure_from_vm(g, vm_window);


### PR DESCRIPTION
Hi @marmarek and @DemiMarie,

I believe that I have found the root cause of the "GUI-related lingering Xen grant references" issue reported in https://github.com/QubesOS/qubes-issues/issues/7539, and I prepared this patch to resolve it.

As noted in the commit message, I have only tested this with Qubes OS v4.1, but I do not see why this commit would not work on the master branch.

Thank you,

Vefa