### PR TITLE
xside: do not release buffer of the "whole screen" window

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -3504,7 +3504,8 @@ static void handle_message(Ghandles * g)
             break;
         vm_window->is_mapped = 0;
         (void) XUnmapWindow(g->display, vm_window->local_winid);
-        release_mapped_mfns(g, vm_window);
+        if (vm_window->remote_winid != FULLSCREEN_WINDOW_ID)
+            release_mapped_mfns(g, vm_window);
         break;
     case MSG_CONFIGURE:
         handle_configure_from_vm(g, vm_window);


### PR DESCRIPTION
That window is backing buffers of other windows too. Windows GUI agent
depends on this feature. The window itself is mapped/unmapped when
switching between seamless and fill desktop modes.

Fixes QubesOS/qubes-issues#7643