### PR TITLE
Support pipewire-pulseaudio as well as pulseaudio

### DIFF
--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -86,7 +86,11 @@ policy files etc.
 %package -n qubes-audio-daemon
 Summary:	The Qubes AUDIO virtualization
 Requires:	pulseaudio-libs
+%if 0%{?fedora} >= 35
+Requires:	pulseaudio-daemon
+%else
 Requires:	pulseaudio
+%endif
 Requires:	libconfig
 Requires:	qubes-libvchan-@BACKEND_VMM@
 Requires:   qubes-utils >= 3.1.0


### PR DESCRIPTION
pacat-simple-vchan works with PipeWire's PulseAudio server, not just
with PulseAudio itself.  Depend on the pulseaudio-daemon feature, which
is provided by both pipewire-pulesaudio and pulseaudio.