### PR TITLE
Fix function prototype mismatches and use poll(2)

### DIFF
--- a/gui-common/double-buffer.c
+++ b/gui-common/double-buffer.c
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <double-buffer.h>
+
 static char *buffer;
 static int buffer_size;
 static int data_offset;

--- a/gui-common/error.c
+++ b/gui-common/error.c
@@ -22,8 +22,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include  <X11/Xlib.h>
+#include <X11/Xlib.h>
 #include <X11/Xlibint.h>
+#include <string.h>
+
+#include "error.h"
 int dummy_handler(Display * dpy, XErrorEvent * ev)
 {
 #define ERROR_BUF_SIZE 256

--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -31,7 +31,7 @@ extra_cflags := -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC \
 		-fno-strict-aliasing \
 		-fno-strict-overflow \
 		-fno-delete-null-pointer-checks \
-		-Wp,-D_FORTIFY_SOURCE=2
+		-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GNU_SOURCE -Werror=missing-prototypes
 
 LDLIBS := $(shell pkg-config --libs $(pkgs))
 all: qubes-guid # qubes-guid.1

--- a/gui-daemon/png.c
+++ b/gui-daemon/png.c
@@ -1,4 +1,5 @@
 #include <png.h>
+#include "./png.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -7,7 +8,7 @@
 
 #define PNGHEADER 8
 
-long *load_png(const char *fname, int *ret_size)
+unsigned long *load_png(const char *fname, int *ret_size)
 {
     static FILE *fp = NULL;
     unsigned char header[PNGHEADER];
@@ -114,7 +115,7 @@ long *load_png(const char *fname, int *ret_size)
     if (ret_size)
         *ret_size = data_size;
 
-    return (long *) data;
+    return (unsigned long *) data;
 
 error:
     if (data)

--- a/gui-daemon/trayicon.c
+++ b/gui-daemon/trayicon.c
@@ -28,6 +28,7 @@
 #include <math.h>
 #include "xside.h"
 #include <util.h>
+#include "trayicon.h"
 
 /* initialization required for TRAY_BACKGROUND mode */
 void init_tray_bg(Ghandles *g) {

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -251,7 +251,7 @@ qubes_xcb_handler(Ghandles *g, const char *msg, struct windowdata *vm_window,
     dummy_handler(g->display, &err);
 }
 
-int x11_error_handler(Display * dpy, XErrorEvent * ev)
+static int x11_error_handler(Display * dpy, XErrorEvent * ev)
 {
     /* log the error */
     dummy_handler(dpy, ev);
@@ -734,7 +734,7 @@ static void mkghandles(Ghandles * g)
 }
 
 /* reload X server parameters, especially after monitor/screen layout change */
-void reload(Ghandles * g) {
+static void reload(Ghandles * g) {
     XWindowAttributes attr;
 
     g->screen = DefaultScreen(g->display);
@@ -4297,7 +4297,7 @@ static void set_alive_flag(int domid)
     close(guid_boot_lock);
 }
 
-void vchan_close()
+static void vchan_close()
 {
     libvchan_close(ghandles.vchan);
 }
@@ -4331,7 +4331,7 @@ static void cleanup() {
 }
 
 static char** restart_argv;
-void restart_guid() {
+static void restart_guid() {
     cleanup();
     execv("/usr/bin/qubes-guid", restart_argv);
     perror("execv");
@@ -4538,8 +4538,6 @@ int main(int argc, char **argv)
     send_xconf(&ghandles);
 
     for (;;) {
-        int select_fds[2] = { xfd };
-        fd_set retset;
         int busy;
         if (ghandles.reload_requested) {
             fprintf(stderr, "reloading X server parameters...\n");
@@ -4557,7 +4555,7 @@ int main(int argc, char **argv)
                 busy = 1;
             }
         } while (busy);
-        wait_for_vchan_or_argfd(ghandles.vchan, 1, select_fds, &retset);
+        wait_for_vchan_or_argfd(ghandles.vchan, xfd);
     }
     return 0;
 }

--- a/include/txrx.h
+++ b/include/txrx.h
@@ -22,7 +22,6 @@
 #ifndef _QUBES_TXRX_H
 #define _QUBES_TXRX_H
 
-#include <sys/select.h>
 #include <libvchan.h>
 
 int write_data(libvchan_t *vchan, char *buf, int size);
@@ -34,7 +33,7 @@ int read_data(libvchan_t *vchan, char *buf, int size);
     x.untrusted_len = sizeof(y); \
     real_write_message(vchan, (char*)&x, sizeof(x), (char*)&y, sizeof(y)); \
     } while(0)
-void wait_for_vchan_or_argfd(libvchan_t *vchan, int nfd, int *fd, fd_set * retset);
+int wait_for_vchan_or_argfd(libvchan_t *vchan, int fd);
 void vchan_register_at_eof(void (*new_vchan_at_eof)(void));
 
 #endif /* _QUBES_TXRX_H */


### PR DESCRIPTION
This fixes function prototype mismatches (caught using
-Wmissing-prototypes) and replaces select(2) with poll(2).  No change in
behavior.