### PR TITLE
Actually unset override-redirect when docking

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -3105,10 +3105,9 @@ static void handle_dock(Ghandles * g, struct windowdata *vm_window)
                 "clearing override-redirect\n",
                 (int) vm_window->local_winid);
         /* changing directly is safe, because window is not mapped here yet */
-        attr.override_redirect = vm_window->override_redirect;
+        attr.override_redirect = vm_window->override_redirect = 0;
         XChangeWindowAttributes(g->display, vm_window->local_winid,
                 CWOverrideRedirect, &attr);
-        vm_window->override_redirect = 0;
     }
     if (vm_window->parent) {
         fprintf(stderr, "cannot dock non-top level window 0x%x\n",


### PR DESCRIPTION
This was supposed to be done in 157ca1496ae0a6e578c124eb0c57217268d3ea3d, but the implementation was wrong: it set the override-redirect flag to what the GUI daemon thought the current value was, not 0.  Therefore, the GUI daemon could become confused as to the override-redirect state of a window.

This turns out not to be exploitable in practice unless subwindows are enabled.  With subwindows disabled, it is not possible to prevent the window from being marked as docked, which prevents moving, resizing, or mapping the window.  Since the window cannot be mapped by the VM, it cannot appear on screen unless the embedder tells the GUI daemon to map it.  The embedder will resize the window before sending this message, so there is no window of vulnerability.

Fixes: 157ca1496ae0a6e578c124eb0c57217268d3ea3d ("Unset override-redirect flag when docking, instead of preventing dock")