### PR TITLE
Strictly validate message lengths

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -4444,7 +4444,7 @@ int main(int argc, char **argv)
                 process_xevent(&ghandles);
                 busy = 1;
             }
-            if (libvchan_data_ready(ghandles.vchan)) {
+            if (libvchan_data_ready(ghandles.vchan) >= (int)sizeof(struct msg_hdr)) {
                 handle_message(&ghandles);
                 busy = 1;
             }


### PR DESCRIPTION
The future Wayland agent will include a proxy for the X11 agent.  This proxy will rely on the `untrusted_len` field for message framing.  If the value in this field does not match the number of bytes the GUI daemon actually reads, chaos will ensue.

To catch this problem before it can create havoc, validate that the `untrusted_len` field of incoming messages is correct.  Furthermore, any validation error that happens before all input has been read is now fatal, as continuing would leave data in the input stream that would be parsed as future protocol messages.  Therefore, do not use `VERIFY()`, which asks the user if they wish to continue.  Instead, log a fatal error and exit.