### PR TITLE
Deal with delayed pulseaudio agent startup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,4 @@
 include:
-- file: /r4.1/gitlab-base.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-dom0.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-vm.yml
-  project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-base.yml
   project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-host.yml

--- a/pulse/pacat-simple-vchan.c
+++ b/pulse/pacat-simple-vchan.c
@@ -403,18 +403,18 @@ static void stream_state_callback(pa_stream *s, void *userdata) {
 
     switch (pa_stream_get_state(s)) {
         case PA_STREAM_CREATING:
-	    break;
+            break;
         case PA_STREAM_TERMINATED:
-	    if (u->play_stdio_event && u->play_stream == s) {
-               pacat_log("play stream terminated");
-		assert(u->mainloop_api);
-		u->mainloop_api->io_free(u->play_stdio_event);
-	    }
-	    if (u->rec_stdio_event && u->rec_stream == s) {
-               pacat_log("rec stream terminated");
-		assert(u->mainloop_api);
-		u->mainloop_api->io_free(u->rec_stdio_event);
-	    }
+            if (u->play_stdio_event && u->play_stream == s) {
+                pacat_log("play stream terminated");
+                assert(u->mainloop_api);
+                u->mainloop_api->io_free(u->play_stdio_event);
+            }
+            if (u->rec_stdio_event && u->rec_stream == s) {
+                pacat_log("rec stream terminated");
+                assert(u->mainloop_api);
+                u->mainloop_api->io_free(u->rec_stdio_event);
+            }
             break;
 
         case PA_STREAM_READY:
@@ -440,22 +440,22 @@ static void stream_state_callback(pa_stream *s, void *userdata) {
                         pa_stream_get_device_index(s),
                         pa_stream_is_suspended(s) ? "" : "not ");
             }
-	    if (u->play_stream == s) {
-		u->play_stdio_event = u->mainloop_api->io_new(u->mainloop_api,
+            if (u->play_stream == s) {
+                u->play_stdio_event = u->mainloop_api->io_new(u->mainloop_api,
                     libvchan_fd_for_select(u->play_ctrl), PA_IO_EVENT_INPUT, vchan_play_callback,  u);
-		if (!u->play_stdio_event) {
-		    pacat_log("io_new play failed");
-		    quit(u, 1);
-		}
-	    }
-	    if (u->rec_stream == s) {
-		u->rec_stdio_event = u->mainloop_api->io_new(u->mainloop_api,
-			libvchan_fd_for_select(u->rec_ctrl), PA_IO_EVENT_INPUT, vchan_rec_callback, u);
-		if (!u->rec_stdio_event) {
-		    pacat_log("io_new rec failed");
-		    quit(u, 1);
-		}
-	    }
+                if (!u->play_stdio_event) {
+                    pacat_log("io_new play failed");
+                    quit(u, 1);
+                }
+            }
+            if (u->rec_stream == s) {
+                u->rec_stdio_event = u->mainloop_api->io_new(u->mainloop_api,
+                        libvchan_fd_for_select(u->rec_ctrl), PA_IO_EVENT_INPUT, vchan_rec_callback, u);
+                if (!u->rec_stdio_event) {
+                    pacat_log("io_new rec failed");
+                    quit(u, 1);
+                }
+            }
             break;
 
         case PA_STREAM_FAILED:

--- a/pulse/pacat-simple-vchan.h
+++ b/pulse/pacat-simple-vchan.h
@@ -26,6 +26,8 @@ struct userdata {
 
     pa_io_event* play_stdio_event;
     pa_io_event* rec_stdio_event;
+    pa_io_event* play_ctrl_event;
+    pa_io_event* rec_ctrl_event;
 
     int rec_allowed;
     int rec_requested;

--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -35,7 +35,6 @@ URL:		http://www.qubes-os.org
 Requires:	xorg-x11-server-Xorg
 Requires:	service(graphical-login)
 Requires:	libconfig
-Requires:	qubes-libvchan-@BACKEND_VMM@
 Requires:   python%{python3_pkgversion}-xcffib
 Requires:   qubes-utils >= 3.1.0
 Requires:   qubes-core-qrexec >= 4.1.5
@@ -94,7 +93,6 @@ Requires:	pulseaudio-daemon
 Requires:	pulseaudio
 %endif
 Requires:	libconfig
-Requires:	qubes-libvchan-@BACKEND_VMM@
 Requires:   qubes-utils >= 3.1.0
 Requires:   python%{python3_pkgversion}-pydbus
 


### PR DESCRIPTION
With pulseaudio socket activation, pulseaudio agent may not be running 
initially. This would be fine generally, as pacat-simple-vchan waits for 
the other end to start first, but it prevents attaching a microphone to the
VM before starting audio-recording app. Fix this by using async vchan
connection, and setup control socket early. Then connect to the actual
pulseaudio daemon (and setup audio streams) only when vchan connection get
established.

Fixes QubesOS/qubes-issues#7964

Depends on https://github.com/QubesOS/qubes-core-vchan-xen/pull/31