### PR TITLE
Drain playback stream before corking it

### DIFF
--- a/pulse/pacat-simple-vchan.h
+++ b/pulse/pacat-simple-vchan.h
@@ -29,15 +29,16 @@ struct userdata {
     pa_io_event* play_ctrl_event;
     pa_io_event* rec_ctrl_event;
 
-    int rec_allowed;
-    int rec_requested;
     GMutex prop_mutex;
     qdb_handle_t qdb;
     char *qdb_path;
     int control_socket_fd;
     pa_io_event* control_socket_event;
+    bool rec_allowed;
+    bool rec_requested;
     bool never_block;
     bool pending_play_cork;
+    bool draining;
 };
 
 void pacat_log(const char *fmt, ...);

--- a/pulse/pacat-simple-vchan.h
+++ b/pulse/pacat-simple-vchan.h
@@ -36,7 +36,7 @@ struct userdata {
     pa_io_event* control_socket_event;
     bool rec_allowed;
     bool rec_requested;
-    bool never_block;
+    int8_t never_block;
     bool pending_play_cork;
     bool draining;
 };

--- a/pulse/pacat-simple-vchan.h
+++ b/pulse/pacat-simple-vchan.h
@@ -37,6 +37,7 @@ struct userdata {
     int control_socket_fd;
     pa_io_event* control_socket_event;
     bool never_block;
+    bool pending_play_cork;
 };
 
 void pacat_log(const char *fmt, ...);


### PR DESCRIPTION
This ensures that there is no data remaining in the playback vchan. Otherwise, this data would be played when the VM _next_ starts playing audio, which is clearly wrong.

Reported-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
Fixes: QubesOS/qubes-issues#8137