### PR TITLE
Allow periods in qube names

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,8 @@ Build-Depends:
  libpng-dev,
  libnotify-dev,
  qubesdb-dev,
- help2man
+ help2man,
+ libqubes-pure-dev,
 Standards-Version: 4.1.3
 Homepage: https://qubes-os.org/
 Vcs-Browser: https://github.com/QubesOS/qubes-gui-daemon

--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -33,7 +33,7 @@ extra_cflags := -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC \
 		-fno-delete-null-pointer-checks \
 		-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GNU_SOURCE -Werror=missing-prototypes
 
-LDLIBS := $(shell pkg-config --libs $(pkgs))
+LDLIBS := $(shell pkg-config --libs $(pkgs)) -lqubes-pure
 all: qubes-guid # qubes-guid.1
 vpath %.c ../common
 qubes-guid: $(objs)

--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -35,16 +35,16 @@ URL:		http://www.qubes-os.org
 Requires:	xorg-x11-server-Xorg
 Requires:	service(graphical-login)
 Requires:	libconfig
-Requires:   python%{python3_pkgversion}-xcffib
-Requires:   qubes-utils >= 3.1.0
-Requires:   qubes-core-qrexec >= 4.1.5
-Requires:   python%{python3_pkgversion}-qubesimgconverter >= 4.1.4
-Requires:   socat
-Requires:   group(qubes)
+Requires:	python%{python3_pkgversion}-xcffib
+Requires:	qubes-utils >= 4.2.10
+Requires:	qubes-core-qrexec >= 4.1.5
+Requires:	python%{python3_pkgversion}-qubesimgconverter >= 4.1.4
+Requires:	socat
+Requires:	group(qubes)
 
-BuildRequires:  python%{python3_pkgversion}-devel
-BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  pulseaudio-libs-devel
+BuildRequires:	python%{python3_pkgversion}-devel
+BuildRequires:	python%{python3_pkgversion}-setuptools
+BuildRequires:	pulseaudio-libs-devel
 BuildRequires:	pkgconfig(x11)
 BuildRequires:	pkgconfig(x11-xcb)
 BuildRequires:	pkgconfig(xcb)
@@ -62,6 +62,7 @@ BuildRequires:	qubes-core-libs-devel >= 1.6.1
 BuildRequires:	qubes-core-libs
 BuildRequires:	qubes-gui-common-devel >= 3.2.0
 BuildRequires:	qubes-libvchan-@BACKEND_VMM@-devel
+BuildRequires:	qubes-utils-devel >= 4.2.10
 
 Source0: %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
This allows periods in qube names by using the function from libqubes-pure to validate them instead of the built-in version.

Part of QubesOS/qubes-issues#8199.