### PR TITLE
Allow periods in qube names

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,8 @@ Build-Depends:
  libpng-dev,
  libnotify-dev,
  qubesdb-dev,
- help2man
+ help2man,
+ libqubes-pure-dev,
 Standards-Version: 4.1.3
 Homepage: https://qubes-os.org/
 Vcs-Browser: https://github.com/QubesOS/qubes-gui-daemon

--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -33,7 +33,7 @@ extra_cflags := -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC \
 		-fno-delete-null-pointer-checks \
 		-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GNU_SOURCE -Werror=missing-prototypes
 
-LDLIBS := $(shell pkg-config --libs $(pkgs))
+LDLIBS := $(shell pkg-config --libs $(pkgs)) -lqubes-pure
 all: qubes-guid # qubes-guid.1
 vpath %.c ../common
 qubes-guid: $(objs)

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -64,6 +64,7 @@
 #include "trayicon.h"
 #include "shm-args.h"
 #include "util.h"
+#include <qubes/pure.h>
 
 /* Supported protocol version */
 
@@ -3897,28 +3898,6 @@ static void parse_trayicon_mode(Ghandles *g, const char *mode_str) {
     }
 }
 
-static _Bool parse_vm_name(const char *arg, Ghandles *g) {
-    if (('a' > *arg || *arg > 'z') &&
-        ('A' > *arg || *arg > 'Z'))
-        return false;
-    for (size_t i = 1; i < sizeof(g->vmname); ++i) {
-        switch (arg[i]) {
-        case 'A'...'Z':
-        case 'a'...'z':
-        case '0'...'9':
-        case '-':
-        case '_':
-            continue;
-        case '\0':
-            memcpy(g->vmname, arg, i + 1);
-            return true;
-        default:
-            return false;
-        }
-    }
-    return false;
-}
-
 /* FIXME: should be in a utility library */
 static uint16_t parse_domid(const char *num)
 {
@@ -3973,11 +3952,15 @@ static void parse_cmdline(Ghandles * g, int argc, char **argv)
                 errx(1, "Cannot specify target domid more than once (previous value %u)", g->target_domid);
             g->target_domid = parse_domid(optarg);
             break;
-        case 'N':
-            if (parse_vm_name(optarg, g))
-                break;
-            fprintf(stderr, "domain name not valid");
-            exit(1);
+        case 'N': {
+            struct QubesSlice s = qubes_pure_buffer_init_from_nul_terminated_string(optarg);
+            if (qubes_pure_is_valid_qube_name(s) != QUBE_NAME_OK)
+                errx(1, "domain name '%s' not valid", optarg);
+            if (s.length >= sizeof(g->vmname))
+                errx(1, "domain name '%s' is too long (this is a bug)", optarg);
+            memcpy(g->vmname, s.pointer, s.length + 1);
+            break;
+        }
         case 'c':
             g->cmdline_color = optarg;
             break;

--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -35,16 +35,16 @@ URL:		http://www.qubes-os.org
 Requires:	xorg-x11-server-Xorg
 Requires:	service(graphical-login)
 Requires:	libconfig
-Requires:   python%{python3_pkgversion}-xcffib
-Requires:   qubes-utils >= 3.1.0
-Requires:   qubes-core-qrexec >= 4.1.5
-Requires:   python%{python3_pkgversion}-qubesimgconverter >= 4.1.4
-Requires:   socat
-Requires:   group(qubes)
+Requires:	python%{python3_pkgversion}-xcffib
+Requires:	qubes-utils >= 4.2.10
+Requires:	qubes-core-qrexec >= 4.1.5
+Requires:	python%{python3_pkgversion}-qubesimgconverter >= 4.1.4
+Requires:	socat
+Requires:	group(qubes)
 
-BuildRequires:  python%{python3_pkgversion}-devel
-BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  pulseaudio-libs-devel
+BuildRequires:	python%{python3_pkgversion}-devel
+BuildRequires:	python%{python3_pkgversion}-setuptools
+BuildRequires:	pulseaudio-libs-devel
 BuildRequires:	pkgconfig(x11)
 BuildRequires:	pkgconfig(x11-xcb)
 BuildRequires:	pkgconfig(xcb)
@@ -62,6 +62,7 @@ BuildRequires:	qubes-core-libs-devel >= 1.6.1
 BuildRequires:	qubes-core-libs
 BuildRequires:	qubes-gui-common-devel >= 3.2.0
 BuildRequires:	qubes-libvchan-@BACKEND_VMM@-devel
+BuildRequires:	qubes-utils-devel >= 4.2.10
 
 Source0: %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
This uses the validation function from libqubes-pure (which permits periods) instead of the old built-in version (which does not).

Part of QubesOS/qubes-issues#8199.

This reverts commit 1ba805168621ceaadf1610816d3299eb474473e8.