### PR TITLE
Always block on vchan I/O by default

### DIFF
--- a/pulse/pacat-simple-vchan.h
+++ b/pulse/pacat-simple-vchan.h
@@ -1,6 +1,7 @@
 #ifndef __PACAT_SIMPLE_VCHAN_H
 #define __PACAT_SIMPLE_VCHAN_H
 
+#include <stdbool.h>
 #include <pulse/pulseaudio.h>
 #include <glib.h>
 #include <libvchan.h>
@@ -36,7 +37,7 @@ struct userdata {
     pa_io_event* control_socket_event;
     bool rec_allowed;
     bool rec_requested;
-    int8_t never_block;
+    bool never_block;
     bool pending_play_cork;
     bool draining;
 };


### PR DESCRIPTION
This significantly improves audio quality compared to nonblocking mode. I believe this is because the PipeWire agent will usually be able to free up space in the capture vchan quickly enough to avoid an overrun.

This has not been tested directly, but it is equivalent to always passing -b as a command-line argument, which I did test.

Fixes: QubesOS/qubes-issues#8887