### PR TITLE
Add basic SELinux policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,17 @@ help:
 	    echo "make clean                <--- clean all the binary files";\
 	    exit 0;
 
+selinux_policies ::= qubes-gui-daemon.pp
+
 all_targets := gui-daemon/qubes-guid gui-daemon/qubes-guid.1 \
      shmoverride/shmoverride.so \
      shmoverride/X-wrapper-qubes pulse/pacat-simple-vchan \
      screen-layout-handler/watch-screen-layout-changes
 
+
 all: $(all_targets)
-.PHONY: $(all_targets) install tar clean help
+all-selinux: selinux/$(selinux_policies)
+.PHONY: $(all_targets) all-selinux install tar clean help
 
 gui-daemon/qubes-guid gui-daemon/qubes-guid.1:
 	$(MAKE) -C gui-daemon qubes-guid qubes-guid.1
@@ -54,6 +58,9 @@ pulse/pacat-simple-vchan:
 screen-layout-handler/watch-screen-layout-changes:
 	$(MAKE) -C screen-layout-handler watch-screen-layout-changes
 
+selinux/$(selinux_policies):
+	$(MAKE) -C selinux -f /usr/share/selinux/devel/Makefile
+
 install:
 	install -D gui-daemon/qubes-guid $(DESTDIR)/usr/bin/qubes-guid
 	install -m 0644 -D gui-daemon/qubes-guid.1 $(DESTDIR)$(MANDIR)/man1/qubes-guid.1
@@ -68,6 +75,9 @@ install:
 	install -D screen-layout-handler/watch-screen-layout-changes $(DESTDIR)/usr/libexec/qubes/watch-screen-layout-changes
 	install -D -m 0644 screen-layout-handler/qubes-screen-layout-watches.desktop $(DESTDIR)/etc/xdg/autostart/qubes-screen-layout-watches.desktop
 	$(MAKE) -C window-icon-updater install
+
+install-selinux:
+	install -D -t $(DESTDIR)/usr/share/selinux/packages selinux/$(selinux_policies)
 
 tar:
 	git archive --format=tar --prefix=qubes-gui/ HEAD -o qubes-gui.tar

--- a/rpm_spec/gui-daemon.spec.in
+++ b/rpm_spec/gui-daemon.spec.in
@@ -41,6 +41,7 @@ Requires:	qubes-core-qrexec >= 4.1.5
 Requires:	python%{python3_pkgversion}-qubesimgconverter >= 4.1.4
 Requires:	socat
 Requires:	group(qubes)
+Requires:   (%{name}-selinux if selinux-policy)
 
 BuildRequires:	python%{python3_pkgversion}-devel
 BuildRequires:	python%{python3_pkgversion}-setuptools
@@ -63,6 +64,7 @@ BuildRequires:	qubes-core-libs
 BuildRequires:	qubes-gui-common-devel >= 3.2.0
 BuildRequires:	qubes-libvchan-@BACKEND_VMM@-devel
 BuildRequires:	qubes-utils-devel >= 4.2.10
+BuildRequires:  selinux-policy-devel
 
 Source0: %{name}-%{version}.tar.gz
 
@@ -110,13 +112,37 @@ Requires:   python%{python3_pkgversion}-setuptools
 Dom0 files for Qubes AUDIO virtualization. This include core-admin extension,
 policy files etc.
 
+%package selinux
+
+BuildRequires: selinux-policy
+%{?selinux_requires}
+
+Summary: SELinux policy for qubes-gui-daemon
+License: GPLv2+
+
+%description selinux
+SELinux policy for qubes-gui-daemon.  You need this package to run qubes-guid
+on a system where SELinux is in enforcing mode.
+
+%post selinux
+%selinux_modules_install %{_datadir}/selinux/packages/qubes-gui-daemon.pp || :
+
+%postun selinux
+if [ "$1" -eq 0 ]; then
+    %selinux_modules_uninstall %{_datadir}/selinux/packages/qubes-gui-daemon.pp
+fi || :
+
+%posttrans selinux
+%selinux_relabel_post
+exit 0
+
 %prep
 %setup -q
 
 %build
 %{?set_build_flags}
 make clean
-make all BACKEND_VMM=@BACKEND_VMM@
+make all all-selinux BACKEND_VMM=@BACKEND_VMM@
 
 %py3_build
 
@@ -125,6 +151,7 @@ make all BACKEND_VMM=@BACKEND_VMM@
 %install
 rm -rf $RPM_BUILD_ROOT
 %make_install
+make install-selinux DESTDIR=$RPM_BUILD_ROOT
 %py3_install
 
 %triggerin -- xorg-x11-server-Xorg
@@ -166,6 +193,9 @@ rm -f %{name}-%{version}
 %files -n qubes-audio-dom0
 %{python3_sitelib}/qubesguidaemon-*.egg-info
 %{python3_sitelib}/qubesguidaemon
+
+%files selinux
+%{_datadir}/selinux/packages/qubes-gui-daemon.pp
 
 %changelog
 @CHANGELOG@

--- a/selinux/qubes-gui-daemon.fc
+++ b/selinux/qubes-gui-daemon.fc
@@ -1,0 +1,3 @@
+/usr/bin/X-wrapper-qubes -- gen_context(system_u:object_r:xserver_exec_t)
+/run/qubes/shm\.id\.[0-9]+ -- gen_context(system_u:object_r:qubes_gui_shmid_t)
+/var/run/qubes/shm\.id\.[0-9]+ -- gen_context(system_u:object_r:qubes_gui_shmid_t)

--- a/selinux/qubes-gui-daemon.te
+++ b/selinux/qubes-gui-daemon.te
@@ -1,0 +1,21 @@
+policy_module(qubes-gui-daemon, 0.0.1)
+
+require {
+    type xserver_t, qubes_var_run_t;
+    type tmpfs_t;
+    type unconfined_t;
+}
+
+type qubes_gui_shmid_t;
+
+# Allow /run/qubes/shm.id.*
+filetrans_pattern(xserver_t, qubes_var_run_t, qubes_gui_shmid_t, file, "shm.id.0")
+filetrans_pattern(xserver_t, qubes_var_run_t, qubes_gui_shmid_t, file, "shm.id.1")
+filetrans_pattern(xserver_t, qubes_var_run_t, qubes_gui_shmid_t, file, "shm.id.2")
+filetrans_pattern(xserver_t, qubes_var_run_t, qubes_gui_shmid_t, file, "shm.id.3")
+filetrans_pattern(xserver_t, qubes_var_run_t, qubes_gui_shmid_t, file, "shm.id.4")
+allow xserver_t qubes_gui_shmid_t:file { create lock open read write map unlink getattr setattr };
+allow qubes_gui_shmid_t tmpfs_t:filesystem { associate };
+
+# until qubes-guid gets its own type
+allow unconfined_t qubes_gui_shmid_t:file mmap_rw_file_perms;


### PR DESCRIPTION
This adds just enough for sys-gui-vnc to work, specifically to allow X
server access to /run/qubes/shm.id.0.

The actual GUI daemon remains unconfined at this time.

QubesOS/qubes-issues#9276