### PR TITLE
Add window_background_color config setting

### DIFF
--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -70,6 +70,13 @@ global: {
   #
   # trayicon_mode = "border1";
 
+  # Set the fill color to be shown in a window when content is pending or
+  # unavailable. This is rarely visible except very briefly. Possible values are
+  # a color name (see: /etc/X11/rgb.txt) or a specification in format 0xRRGGBB.
+  # When running a dark-styled desktop theme, "black" is recommended.
+  #
+  # window_background_color = "white";
+
   # Timeout when waiting for qubes-gui-agent
   #
   # startup_timeout = 45;

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -225,6 +225,8 @@ struct _global_handles {
     int trayicon_border; /* position of trayicon border - 0 - no border, 1 - at the edges, 2 - 1px from the edges */
     bool trayicon_tint_reduce_saturation; /* reduce trayicon saturation by 50% (available only for "tint" mode) */
     bool trayicon_tint_whitehack; /* replace white pixels with almost-white 0xfefefe (available only for "tint" mode) */
+    const char *window_background_color_pre_parse; /* user-provided description of window background pixel */
+    unsigned long window_background_pixel;         /* parsed version of the above */
     bool disable_override_redirect; /* Disable “override redirect” windows */
     char *screensaver_names[MAX_SCREENSAVER_NAMES]; /* WM_CLASS names for windows detected as screensavers */
     Cursor *cursors;  /* preloaded cursors (using XCreateFontCursor) */


### PR DESCRIPTION
Note: in QubesOS/qubes-issues#9304 I wrote:

> My instinct is that an option of black or white is good enough; allowing the color to be an arbitrary hue perhaps grants this issue more attention than it deserves. Also, the implementation is simpler. But I defer to others.

I changed my mind about this in the meantime, I like dark blue, and in this change I allow the setting to be an arbitrary user-selected color. This obligates some error checking around `strtoul` and `XAllocNamedColor`. (An input sanitizing step upstream in memory-safe `qvm-features` -- QubesOS/qubes-issues#7730 -- would be a good complement.) If the user-selected color is invalid, `qubes-guid` bails with an error logged to `/var/log/qubes/guid.<vm>.log`.

I think this is ok? But let me know.

Fixes QubesOS/qubes-issues#9304