### PR TITLE
Fix: make shmoverride.so initfirst

### DIFF
--- a/shmoverride/shmoverride.c
+++ b/shmoverride/shmoverride.c
@@ -72,6 +72,8 @@ static int (*real_munmap) (void *shmaddr, size_t len);
 static int (*real_fstat64) (VER_ARG int fd, struct stat64 *buf);
 static int (*real_fstat)(VER_ARG int fd, struct stat *buf);
 
+static int try_init(void);
+
 static struct stat global_buf;
 static int gntdev_fd = -1;
 
@@ -84,7 +86,7 @@ static int xc_hnd;
 static xengnttab_handle *xgt;
 static char __shmid_filename[SHMID_FILENAME_LEN];
 static char *shmid_filename = NULL;
-static int idfd = -1, display = -1;
+static int idfd = -1, display = -1, init_called = 0;
 
 static uint8_t *mmap_mfns(struct shm_args_hdr *shm_args) {
     uint8_t *map;
@@ -150,6 +152,8 @@ ASM_DEF(void *, mmap,
         real_fstat64 = FSTAT64;
         real_fstat = FSTAT;
     }
+
+    try_init();
 
 #if defined MAP_ANON && defined MAP_ANONYMOUS && (MAP_ANONYMOUS) != (MAP_ANON)
 # error header bug (def mismatch)
@@ -217,6 +221,9 @@ ASM_DEF(int, munmap, void *addr, size_t len)
 {
     if (len > SIZE_MAX - XC_PAGE_SIZE)
         abort();
+
+    try_init();
+
     const uintptr_t addr_int = (uintptr_t)addr;
     const uintptr_t rounded_addr = addr_int & ~(uintptr_t)(XC_PAGE_SIZE - 1);
     return real_munmap((void *)rounded_addr, len + (addr_int - rounded_addr));
@@ -438,6 +445,7 @@ static int assign_off(off_t *off) {
 
 #define STAT(id)                                          \
 ASM_DEF(int, f ## id, int filedes, struct id *buf) {      \
+    try_init();                                           \
     int res = real_f ## id(VER filedes, buf);             \
     if (res ||                                            \
         !S_ISCHR(buf->st_mode) ||                         \
@@ -454,6 +462,7 @@ STAT(stat64)
 #ifdef _STAT_VER
 #define STAT(id)                                                    \
 ASM_DEF(int, __fx ## id, int ver, int filedes, struct id *buf) {    \
+    try_init();                                                     \
     if (ver != _STAT_VER) {                                         \
         fprintf(stderr,                                             \
                 "Wrong _STAT_VER: got %d, expected %d, libc has incompatibly changed\n", \
@@ -467,8 +476,13 @@ STAT(stat64)
 #undef STAT
 #endif
 
-int __attribute__ ((constructor)) initfunc(void)
+static int try_init(void)
 {
+    // Ideally it is being called in constructor, if something is calling this before
+    // constructor - we're assuming it is not multi-threaded code.
+    if (__builtin_expect(init_called, 1)) return 0;
+    init_called = 1;
+
     unsetenv("LD_PRELOAD");
     fprintf(stderr, "shmoverride constructor running\n");
     dlerror();
@@ -580,6 +594,10 @@ cleanup:
     }
     shm_args = NULL;
     return 0;
+}
+int __attribute__ ((constructor)) initfunc(void)
+{
+    return try_init();
 }
 
 int __attribute__ ((destructor)) descfunc(void)


### PR DESCRIPTION
After I have rebased my qubesos nixos dom0 on latest nixos version, I have encountered Xwayland/Xorg failing with segfault.

The cause of segfault was fstat hook being called before library constructor:
![image](https://github.com/user-attachments/assets/98981f82-a1a2-4000-af94-ba8bbb1a0fa9)

![image](https://github.com/user-attachments/assets/fbe6a779-4135-4a82-bcba-9af3ba51abec)

![image](https://github.com/user-attachments/assets/472491ef-5b80-445d-afe2-e361cd02c85b)

This was not caused by constructor not finding fstat with dlsym, I have checked that no logs being emitted by this library (and double-checked by using bpftrace to catch all fprints to stderr), constructor defenitely was not being called.

I'm not sure why, but `-z initfirst` linker flag fixes this constructor call ordering issue, making constructor being run before fsync, thus fixing the segfault, and restoring the Xwayland/Xorg operation.

I can provide more info/logs about this issue, but my knowledge about dynamic linking is limited, and I have no idea what might be useful here.