### PR TITLE
Add event buffering for cloaking user input patterns

### DIFF
--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -85,4 +85,10 @@ global: {
   # 256 to 256000 characters. Default is 64000 characters.
   #
   # max_clipboard_size = 64000
+
+  # Maximum delay in milliseconds for event buffering (used for obfuscating
+  # biometric data that could be obtained by observing keyboard and mouse
+  # patterns). Set to 0 to disable event buffering entirely.
+  #
+  # events_max_delay = 0;
 }

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -4477,7 +4477,7 @@ static void parse_vm_config(Ghandles * g, config_setting_t * group)
             g->disable_override_redirect = 0;
         else {
             fprintf(stderr,
-                    "unsupported value ‘%s’ for override_redirect (must be ‘disabled’ or ‘allow’)\n",
+                    "unsupported value '%s' for override_redirect (must be 'disabled' or 'allow')\n",
                     value);
             exit(1);
         }

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -4608,7 +4608,7 @@ int main(int argc, char **argv)
     if (!ghandles.nofork) {
         // daemonize...
         if (pipe(pipe_notify) < 0) {
-            perror("canot create pipe:");
+            perror("cannot create pipe:");
             exit(1);
         }
 

--- a/include/txrx.h
+++ b/include/txrx.h
@@ -33,7 +33,7 @@ int read_data(libvchan_t *vchan, char *buf, int size);
     x.untrusted_len = sizeof(y); \
     real_write_message(vchan, (char*)&x, sizeof(x), (char*)&y, sizeof(y)); \
     } while(0)
-int wait_for_vchan_or_argfd(libvchan_t *vchan, int fd);
+int wait_for_vchan_or_argfd_once(libvchan_t *vchan, int fd, int timeout);
 void vchan_register_at_eof(void (*new_vchan_at_eof)(void));
 
 #endif /* _QUBES_TXRX_H */


### PR DESCRIPTION
# Goal

Implement the functionality of [kloak](https://github.com/Whonix/kloak) (a tool designed to hide biometric behavior patterns in keystrokes and mouse movements) in qubes-gui-daemon. This PR will implement the functionality requested in https://github.com/QubesOS/qubes-issues/issues/1850 and fleshed out further in https://github.com/QubesOS/qubes-issues/issues/8541. It will also close https://github.com/QubesOS/qubes-issues/issues/8534 as it will no longer be necessary.

# TODOs

* Test rigorously on Qubes R4.3 (an earlier iteration of the code has been smoke-tested on Qubes R4.2, this hasn't been tested at all on R4.3 yet)

# Fixed TODOs:

* Figure out why the domU window occasionally freezes until another input event is sent - we aren't buffering info coming from domU to dom0 so why this is happening is a mystery to me, and something for later investigation. (Solved, https://github.com/QubesOS/qubes-gui-daemon/pull/149#issuecomment-2387143732)
* Potentially change how events are treated (do some events have to operate in pairs for best results?). (Lots of X events are now not buffered in the latest implementation. Only ones that look valuable to buffer are buffered.)
* Make the delay duration user-configurable (right now it's hardcoded to 150 milliseconds). (Implemented.)
* Allow configuring event delay duration for individual VMs buffering (right now it is applied equally to all VMs). (Implemented.)
* Get the configuration code working and test it. (Solved, this ended up requiring a change to [core-admin-client](https://forum.qubes-os.org/t/cannot-change-qubes-gui-daemon-settings-using-qvm-features/29345/3) which I will be submitting as a separate PR.)
* Ensure all new code adheres to Qubes OS standards (didn't have time to finish that up) (should be done now)

# Rationale

Kloak, the inspiration for this PR, is a user input buffering and obfuscation tool. It intercepts keyboard and mouse events at the evdev layer, holds them in a queue for release at a later scheduled time, then releases them to the applications they were intended for periodically. By adding random noise into the user's input patterns, kloak aims to make otherwise recognizable patterns in user behavior (such as keystroke rhythm and mouse movement patterns) too erratic to be used as a method of identifying the user. This is potentially very useful especially for Whonix Workstation domUs, as it denies an adversary access to a remarkably effective biometric fingerprinting mechanism they could otherwise access without specialized tools.

Kloak is currently able to operate directly in Qubes domUs if (and only if!) `gui-agent-virtual-input-device` is enabled for the domU in question. Even in these instances, only keyboard events are anonymized, and additionally the domU must have an evdev X driver installed. This is less than ideal from a functionality standpoint, and as @DemiMarie has explained in https://github.com/QubesOS/qubes-issues/issues/8541 it will eventually stop working entirely. There's also the possibility of malware compromise in the domU resulting in the deanonymization of the user. For these reasons, enabling the use of evdev in domUs and running kloak in the domU is not a good solution.

The other obvious option is to run kloak directly in dom0. This has several disadvantages:

* kloak can now potentially wreak havoc on the user's ability to use their computer. If a bug in kloak locks up the keyboard, or the user does something inadvisable like setting a 20-second event delay, regaining control of the system could be difficult or impossible without doing a hard reset (or worse, booting an external USB in order to chroot into dom0 and disable kloak).
* Application of kloak's functionality becomes all-or-nothing - you either anonymize all keyboard and mouse input everywhere, or you anonymize none of it. This could make management of dom0 annoying with larger delay times, and it could prevent the user from making use of applications or websites that require input pattern telemetry to function (such as some bank websites).
* kloak's configuration options similarly apply globally. One might want a comfortable delay of only 25ms in a domU they expect to be safe, but wish to use an extremely long one like 1000ms in a domU they believe is compromised and actively exfiltrating data. With kloak running directly in dom0, this is impossible.

This PR implements a third option - *inserting the functionality of kloak directly into qubes-gui-daemon.* kloak upstream never needs to be involved, only the functionality of it must be. This functionality I have termed "event buffering", and as this implementation works with X server events I have called it "event buffering", or "ebuf" for short (which is the term used for it in the code). Previously I had called this "X event buffering" and used "xbuf" for short, but as @3hhh pointed out that name would become inaccurate when this is ported to Wayland, so I changed it to "ebuf" so as to make the name be display server agnostic.

By working inside the GUI daemon, the following advantages are gained:

* No evdev support needed at all, we can work with X events instead.
* The amount of additional code needed is smaller.
* Per-VM application and configuration of event buffering is now possible - some VMs can use a small, comfortable delay, others can use a very long one, and others can skip delays entirely.
* Even if something goes very wrong and buffering prevents the user from inputting anything into any Qube, the user retains control of dom0 and can recover their system from there.
* A compromised domU with event buffering enabled will be less likely to leak valuable biometric info to the malware within the VM.

# How it works

Most of the code should be fairly self-explanatory. In a nutshell, we use a tail queue to store a list of delayed, scheduled X events. As events come from dom0 to a domU, they are captured, scheduled for release at a later time, and thrown into the queue. Events in the queue are regularly checked to see if their scheduled release time has arrived, and those events are released when appropriate. The scheduler inserts some random noise into the delays, making it difficult to uniquely identify the user's typing and mouse movement/usage patterns.

By default, event buffering is disabled and all events are passed through without buffering. To enable it, one must use `qvm-features` to set `gui-ebuf-max-delay` to a value greater than 0. It is worth noting that 0 is interpreted not as a "don't add any delay when buffering events", but rather it is interpreted as "don't buffer events at all". This configuration feature **does not work** without the `ebuf_max_events` setting being added to the list of GUI daemon configuration settings in qubes-core-admin-client. The pull request for that is at https://github.com/QubesOS/qubes-core-admin-client/pull/309.

This PR needs more testing (especially on Qubes R4.3), but it is solid enough that I feel comfortable asking for a review on it. Thanks for your help!