### PR TITLE
Fix bugs in the icon-receiver

### DIFF
--- a/window-icon-updater/icon-receiver
+++ b/window-icon-updater/icon-receiver
@@ -342,7 +342,7 @@ class IconReceiver(object):
         try:
             # Parse header from qrexec
             header = await reader.readuntil(b'\0')
-            header_parts = header.decode('ascii').split(' ').restrip('\x00')
+            header_parts = header.decode('ascii').restrip('\x00').split(' ')
             assert len(header_parts) >= 2, header_parts
 
             service_name = header_parts[0]

--- a/window-icon-updater/icon-receiver
+++ b/window-icon-updater/icon-receiver
@@ -388,7 +388,7 @@ def main():
     args = parser.parse_args()
 
     if not args.force:
-        if (not os.path.exists('/var/run/qubes-service/guivm-gui-agent') and
+        if (not os.path.exists('/var/run/qubes-service/guivm') and
             not os.path.exists('/etc/qubes-release')):
 
             print('Not in GuiVM or dom0, exiting '

--- a/window-icon-updater/icon-receiver
+++ b/window-icon-updater/icon-receiver
@@ -342,7 +342,7 @@ class IconReceiver(object):
         try:
             # Parse header from qrexec
             header = await reader.readuntil(b'\0')
-            header_parts = header.decode('ascii').split(' ')
+            header_parts = header.decode('ascii').split(' ').restrip('\x00')
             assert len(header_parts) >= 2, header_parts
 
             service_name = header_parts[0]

--- a/window-icon-updater/icon-receiver
+++ b/window-icon-updater/icon-receiver
@@ -342,7 +342,7 @@ class IconReceiver(object):
         try:
             # Parse header from qrexec
             header = await reader.readuntil(b'\0')
-            header_parts = header.decode('ascii').restrip('\x00').split(' ')
+            header_parts = header.decode('ascii').rstrip('\x00').split(' ')
             assert len(header_parts) >= 2, header_parts
 
             service_name = header_parts[0]


### PR DESCRIPTION
- Update `guivm-gui-agent` to `guivm`
- When the `icon-reciever` running on guivm other than dom0 the header received is as follow:
  Request coming from appvm to dom0
  ```
  service vm-name keyword adminvm\x00
  ```
  Request coming from appvm to guivm
  ```
  service vm-name\x00
  ```
  The trailing `\x00` cause a bug when trying to get the color of the vm using `qubesadminapi`.