### PR TITLE
Leave defining _FORTIFY_SOURCE to distribution policy

### DIFF
--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -31,7 +31,7 @@ extra_cflags := -I../include/ -g -O2 -Wall -Wextra -Werror -pie -fPIC \
 		-fno-strict-aliasing \
 		-fno-strict-overflow \
 		-fno-delete-null-pointer-checks \
-		-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GNU_SOURCE -Werror=missing-prototypes
+		-Wp,-D_GNU_SOURCE -Werror=missing-prototypes
 
 LDLIBS := $(shell pkg-config --libs $(pkgs)) -lqubes-pure
 all: qubes-guid # qubes-guid.1

--- a/pulse/Makefile
+++ b/pulse/Makefile
@@ -1,6 +1,6 @@
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 CC ?= gcc
-CFLAGS += -Wall -Wextra -Werror -g -O2 -fPIC -D_FORTIFY_SOURCE=2 -fcf-protection -fstack-clash-protection -D_GNU_SOURCE=
+CFLAGS += -Wall -Wextra -Werror -g -O2 -fPIC -fcf-protection -fstack-clash-protection -D_GNU_SOURCE=
 VCHANLIBS=`pkg-config --libs $(VCHAN_PKG)`
 VCHANCFLAGS=`pkg-config --cflags $(VCHAN_PKG)`
 GLIBCFLAGS=`pkg-config --cflags glib-2.0`


### PR DESCRIPTION
Different distributions have different policy about this flag, avoid
setting it here to not conflict with distribution value.

Kinda related to QubesOS/qubes-issues#9597