### PR TITLE
audio: fix reacting on mic enable/disable requests

### DIFF
--- a/pulse/pacat-simple-vchan.h
+++ b/pulse/pacat-simple-vchan.h
@@ -32,6 +32,7 @@ struct userdata {
 
     GMutex prop_mutex;
     qdb_handle_t qdb;
+    qdb_handle_t watch_qdb; // separate connection for watches
     char *qdb_config_path;
     char *qdb_status_path;
     char *qdb_request_path;


### PR DESCRIPTION
After getting an event of QubesDB FD, actually call qdb_read_watch() so
the event is cleared and the next one can be received.

QubesOS/qubes-issues#9619