### PR TITLE
Assure Popup Windows (override-redirect) open over parent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.dep
 tags
 pkgs/
+gui-daemon/qubes-guid


### PR DESCRIPTION
The problem and solution is reported by `vx-sec` on  Github. It was found on Xmonad WM. The fix simply raises the override-redirect window to top, flushes display events and the restack windows for "Keep-on-top" windows to work properly

Also tested on the default XFCE on r4.3

resolves: https://github.com/QubesOS/qubes-issues/issues/9935