### PR TITLE
debian: Support pipewire-pulseaudio as well as pulseaudio

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,7 +48,7 @@ Description: Qubes GUI virtualization (GUI VM side)
 Package: qubes-audio-daemon
 Architecture: any
 Depends:
- pulseaudio,
+ pulseaudio | pipewire-pulse,
  ${shlibs:Depends},
  ${misc:Depends}
 Replaces: qubes-gui-daemon-pulseaudio (<< 4.1.21~)


### PR DESCRIPTION
Follow-up to #111 which did the same for Fedora.

Resolves https://github.com/QubesOS/qubes-issues/issues/9464.