### PR TITLE
Implement trayicon background colouration

### DIFF
--- a/gui-daemon/guid.conf
+++ b/gui-daemon/guid.conf
@@ -70,6 +70,10 @@ global: {
   #
   # trayicon_mode = "border1";
 
+  # Sets the background color of the tray icon. The specification is the same as window_background_color.
+  #
+  # trayicon_background_color = "white";
+
   # Set the fill color to be shown in a window when content is pending or
   # unavailable. This is rarely visible except very briefly. Possible values are
   # a color name (see: /etc/X11/rgb.txt) or a specification in format 0xRRGGBB.

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -717,6 +717,9 @@ static void mkghandles(Ghandles * g)
     else if (g->trayicon_mode == TRAY_TINT)
         init_tray_tint(g);
     /* nothing extra needed for TRAY_BORDER */
+    /* parse trayicon background color */
+    g->trayicon_background_pixel = parse_color(g->trayicon_background_color_pre_parse,
+                                             g->display, g->screen).pixel;
     /* parse window background color */
     g->window_background_pixel = parse_color(g->window_background_color_pre_parse,
                                              g->display, g->screen).pixel;
@@ -4538,6 +4541,7 @@ static void load_default_config_values(Ghandles * g)
     g->trayicon_border = 0;
     g->trayicon_tint_reduce_saturation = 0;
     g->trayicon_tint_whitehack = 0;
+    g->trayicon_background_color_pre_parse = "white";
     g->window_background_color_pre_parse = "white";
 }
 
@@ -4648,6 +4652,11 @@ static void parse_vm_config(Ghandles * g, config_setting_t * group)
     if ((setting =
          config_setting_get_member(group, "trayicon_mode"))) {
         parse_trayicon_mode(g, config_setting_get_string(setting));
+    }
+
+    if ((setting =
+         config_setting_get_member(group, "trayicon_background_color"))) {
+        g->trayicon_background_color_pre_parse = config_setting_get_string(setting);
     }
 
     if ((setting =

--- a/gui-daemon/xside.h
+++ b/gui-daemon/xside.h
@@ -247,7 +247,9 @@ struct _global_handles {
     int trayicon_border; /* position of trayicon border - 0 - no border, 1 - at the edges, 2 - 1px from the edges */
     bool trayicon_tint_reduce_saturation; /* reduce trayicon saturation by 50% (available only for "tint" mode) */
     bool trayicon_tint_whitehack; /* replace white pixels with almost-white 0xfefefe (available only for "tint" mode) */
+    const char *trayicon_background_color_pre_parse; /* user-provided description of trayicon background pixel */
     const char *window_background_color_pre_parse; /* user-provided description of window background pixel */
+    unsigned long trayicon_background_pixel;         /* parsed version of the above */
     unsigned long window_background_pixel;         /* parsed version of the above */
     bool disable_override_redirect; /* Disable “override redirect” windows */
     char *screensaver_names[MAX_SCREENSAVER_NAMES]; /* WM_CLASS names for windows detected as screensavers */


### PR DESCRIPTION
Adds the configuration parameter trayicon_background_color. This functionality works the same way as the pixmap logic in fill_tray_bg_and_update; i.e. it takes the top-left corner value and replaces any pixels with that value with the background colour.

Not a perfect solution; but should mitigate https://github.com/QubesOS/qubes-issues/issues/2846 to some extent.
