### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/window-icon-updater/icon-receiver
+++ b/window-icon-updater/icon-receiver
@@ -408,7 +408,8 @@ def main():
             logging.error("Connection error: %s", e)
             sys.exit(1)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     tasks = [
         rcvd.handle_events(),
         rcvd.handle_clients(),


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

Resolves: QubesOS/qubes-issues#10188