### PR TITLE
Don't event-buffer ConfigureNotify, MapNotify, and ReparentNotify events

### DIFF
--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -2815,7 +2815,16 @@ static void process_xevent(Ghandles * g)
     XEvent event_buffer;
     XNextEvent(g->display, &event_buffer);
     if (g->ebuf_max_delay > 0) {
-        ebuf_queue_xevent(g, event_buffer);
+        switch (event_buffer.type) {
+        case ConfigureNotify:
+        case ReparentNotify:
+        case MapNotify:
+            process_xevent_core(g, event_buffer);
+            break;
+        default:
+            ebuf_queue_xevent(g, event_buffer);
+            break;
+        }
     } else {
         process_xevent_core(g, event_buffer);
     }


### PR DESCRIPTION
When event buffering is enabled for a qube, previously Qt applications would exhibit some strange flickering / element resizing when opening application menus. This appears to be because ConfigureNotify events were being delayed, causing Qt to draw elements of the user interface with incorrect size and position information. It would then likely have to redraw the menu with the correct information once that information was available to it.

ConfigureNotify, MapNotify, and ReparentNotify events all look like they can be passed through without negative effects on anonymity, so make them exempt from event buffering. This appears to resolve the flickering issue.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10286