### PR TITLE
Change manufacturer label for dom0:mic

### DIFF
--- a/qubesguidaemon/mic.py
+++ b/qubesguidaemon/mic.py
@@ -60,7 +60,7 @@ class MicDeviceExtension(qubes.ext.Extension):
     @staticmethod
     def get_device(app):
         return MicDevice(
-            app.domains[0], product="microphone", manufacturer="build-in"
+            app.domains[0], product="microphone", manufacturer="default"
         )
 
     @qubes.ext.handler("device-list:mic")


### PR DESCRIPTION
"build-in" should be "built-in", but we don't actually know anything about the hardware in this context. It could also be a modular PCI sound card, or a USB or Bluetooth microphone attached to a different audiovm. "default" is more vague and more likely to be accurate, although even then a different device could be selected e.g. in pavucontrol.