### PR TITLE
pulse: fix race condition whith allowing recording early

### DIFF
--- a/pulse/pacat-simple-vchan.c
+++ b/pulse/pacat-simple-vchan.c
@@ -680,7 +680,7 @@ static bool connect_disconnect_rec_stream_locked(
 
         if (!(u->rec_stream = pa_stream_new_with_proplist(u->context, "record", &sample_spec, &u->channel_map, u->proplist))) {
             pacat_log("rec pa_stream_new() failed: %s", pa_strerror(pa_context_errno(u->context)));
-            quit(u, 1);
+            goto fail;
         }
 
         pa_stream_set_state_callback(u->rec_stream, stream_state_callback, u);
@@ -710,6 +710,9 @@ static bool connect_disconnect_rec_stream_locked(
             u->rec_stream_connect_in_progress = false;
         }
     }
+    return false;
+fail:
+    quit(u, 1);
     return false;
 }
 
@@ -811,6 +814,7 @@ static void context_state_callback(pa_context *c, void *userdata) {
             if (u->rec_stdio_event) {
                 assert(u->mainloop_api);
                 u->mainloop_api->io_free(u->rec_stdio_event);
+                u->rec_stdio_event = NULL;
             }
             quit(u, 0);
             break;
@@ -953,7 +957,12 @@ static void control_socket_callback(pa_mainloop_api *UNUSED(a),
         g_mutex_lock(&u->prop_mutex);
         if (new_rec_allowed != u->rec_allowed) {
             u->rec_allowed = new_rec_allowed;
-            if (!u->rec_stream_connect_in_progress)
+            /* Actually connect/disconnect the stream only if pulseaudio
+             * context is fully set up, up to the point of reading recording
+             * requests. If not yet, context_state_callback() will take care of
+             * it, once it's fully connected.
+             */
+            if (u->rec_stdio_event && !u->rec_stream_connect_in_progress)
                 connect_disconnect_rec_stream_locked(u, false, new_rec_allowed);
             pacat_log("Setting audio-input to %s", u->rec_allowed ? "enabled" : "disabled");
         }

--- a/qubesguidaemon/mic.py
+++ b/qubesguidaemon/mic.py
@@ -19,6 +19,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 """Microphone control extension"""
+
 import asyncio
 import subprocess
 import sys


### PR DESCRIPTION
Listening on qubesdb events is set early, it's possible the request to
allow recording will come before pulseaudio context is fully set. That
may lead to errors like this:

    Connection to qube established, connecting to PulseAudio daemon
    rec pa_stream_new() failed: Invalid argument

Fix this by manipulating recording stream only after pulseaudio is fully
set (use u->rec_stdio_event as a proxy for that info). If it isn't, only
save requested state, context_state_callback() will later connect the
stream.

And also, fix error handling in connect_disconnect_rec_stream_locked() -
return early in case of error, quit() function only schedules
termination, but it does return.
