### PR TITLE
Add Arch Linux packaging for GUI and audio daemons

### DIFF
--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -9,3 +9,6 @@ vm:
   deb:
     build:
     - debian
+  archlinux:
+    build:
+    - archlinux

--- a/archlinux/95-qubes-gui-daemon.hook
+++ b/archlinux/95-qubes-gui-daemon.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = xorg-server
+
+[Action]
+Description = Configuring the Qubes X server wrapper...
+When = PostTransaction
+Exec = /usr/bin/ln -sfn X-wrapper-qubes /usr/bin/X

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -1,0 +1,99 @@
+# The Qubes OS Project, https://www.qubes-os.org
+
+pkgbase=qubes-gui-daemon
+pkgname=(qubes-gui-daemon qubes-audio-daemon)
+pkgver=@VERSION@
+pkgrel=@REL@
+pkgdesc="Qubes GUI and audio virtualization daemons"
+arch=(x86_64)
+url="https://www.qubes-os.org/"
+license=(GPL-2.0-or-later)
+makedepends=(
+    gcc
+    gdk-pixbuf2
+    glib2
+    help2man
+    libconfig
+    libnotify
+    libpng
+    libpulse
+    libx11
+    libxcb
+    libxrandr
+    make
+    pkgconf
+    qubes-db-vm
+    qubes-libvchan
+    'qubes-vm-gui-common>=4.3.0'
+    'qubes-vm-utils>=4.2.10'
+    qubes-vm-xen
+    xcb-util
+)
+_pkgnvr="${pkgbase}-${pkgver}-${pkgrel}"
+source=("${_pkgnvr}.tar.gz")
+sha256sums=(SKIP)
+
+build() {
+    cd "${_pkgnvr}"
+    make all BACKEND_VMM=xen LIBDIR=/usr/lib
+}
+
+package_qubes-gui-daemon() {
+    pkgdesc="Qubes GUI virtualization daemon for GUI domains"
+    depends=(
+        gdk-pixbuf2
+        glib2
+        libconfig
+        libnotify
+        libpng
+        libx11
+        libxcb
+        libxrandr
+        notification-daemon
+        python
+        python-xcffib
+        qubes-core-admin-client
+        'qubes-img-converter>=4.1.4'
+        qubes-libvchan
+        qubes-vm-core
+        'qubes-vm-qrexec>=4.1.5'
+        'qubes-vm-utils>=4.2.10'
+        qubes-vm-xen
+        socat
+        xcb-util
+        xorg-server
+    )
+    optdepends=('qubes-audio-daemon: audio virtualization support')
+    backup=(
+        etc/qubes/guid.conf
+        etc/qubes/rpc-config/qubes.WindowIconUpdater
+    )
+    install=archlinux/qubes-gui-daemon.install
+
+    cd "${_pkgnvr}"
+    make install DESTDIR="${pkgdir}" LIBDIR=/usr/lib
+
+    rm "${pkgdir}/usr/bin/pacat-simple-vchan"
+    rm "${pkgdir}/etc/qubes/policy.d/90-default-gui-daemon.policy"
+    rmdir "${pkgdir}/etc/qubes/policy.d"
+
+    install -Dm644 archlinux/95-qubes-gui-daemon.hook \
+        "${pkgdir}/usr/share/libalpm/hooks/95-qubes-gui-daemon.hook"
+}
+
+package_qubes-audio-daemon() {
+    pkgdesc="Qubes audio virtualization daemon for GUI and audio domains"
+    depends=(
+        glib2
+        libpulse
+        pulse-native-provider
+        qubes-db-vm
+        qubes-libvchan
+    )
+
+    cd "${_pkgnvr}"
+    install -Dm755 pulse/pacat-simple-vchan \
+        "${pkgdir}/usr/bin/pacat-simple-vchan"
+}
+
+# vim:set ts=4 sw=4 et:

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -52,8 +52,6 @@ package_qubes-gui-daemon() {
         notification-daemon
         python
         python-xcffib
-        qubes-core-admin-client
-        'qubes-img-converter>=4.1.4'
         qubes-libvchan
         qubes-vm-core
         'qubes-vm-qrexec>=4.1.5'
@@ -63,7 +61,10 @@ package_qubes-gui-daemon() {
         xcb-util
         xorg-server
     )
-    optdepends=('qubes-audio-daemon: audio virtualization support')
+    optdepends=(
+        'qubes-audio-daemon: audio virtualization support'
+        'qubes-core-admin-client: window icon updates'
+    )
     backup=(
         etc/qubes/guid.conf
         etc/qubes/rpc-config/qubes.WindowIconUpdater

--- a/archlinux/qubes-gui-daemon.install
+++ b/archlinux/qubes-gui-daemon.install
@@ -1,0 +1,22 @@
+configure_qubes_gui_daemon() {
+    if getent group qubes >/dev/null; then
+        chgrp qubes /usr/bin/qubes-guid
+        chmod 4750 /usr/bin/qubes-guid
+    fi
+
+    ln -sfn X-wrapper-qubes /usr/bin/X
+}
+
+post_install() {
+    configure_qubes_gui_daemon
+}
+
+post_upgrade() {
+    configure_qubes_gui_daemon
+}
+
+pre_remove() {
+    if [ "$(readlink /usr/bin/X)" = "X-wrapper-qubes" ]; then
+        ln -sfn Xorg /usr/bin/X
+    fi
+}

--- a/qubesguidaemon/mic.py
+++ b/qubesguidaemon/mic.py
@@ -19,6 +19,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 """Microphone control extension"""
+
 import asyncio
 import subprocess
 import sys
@@ -34,9 +35,7 @@ class MicDevice(DeviceInfo):
     # pylint: disable=too-few-public-methods)
 
     def __init__(self, backend_domain, product, manufacturer):
-        port = Port(
-            backend_domain=backend_domain, port_id="mic", devclass="mic"
-        )
+        port = Port(backend_domain=backend_domain, port_id="mic", devclass="mic")
         super().__init__(
             port,
             product=product,
@@ -59,9 +58,7 @@ class MicDeviceExtension(qubes.ext.Extension):
 
     @staticmethod
     def get_device(app):
-        return MicDevice(
-            app.domains[0], product="microphone", manufacturer="default"
-        )
+        return MicDevice(app.domains[0], product="microphone", manufacturer="default")
 
     @qubes.ext.handler("device-list:mic")
     def on_device_list_mic(self, vm, event):
@@ -135,9 +132,7 @@ class MicDeviceExtension(qubes.ext.Extension):
             "supported-rpc.qubes.AudioInputEnable", False
         ):
             try:
-                await audiovm.run_service_for_stdio(
-                    f"qubes.AudioInputEnable+{vm.name}"
-                )
+                await audiovm.run_service_for_stdio(f"qubes.AudioInputEnable+{vm.name}")
             except subprocess.CalledProcessError:
                 # pylint: disable=raise-missing-from
                 raise qubes.exc.QubesVMError(


### PR DESCRIPTION
## Summary

- add Qubes Builder v2 support for Arch Linux VM packages
- package the GUI and audio daemons separately as `qubes-gui-daemon` and `qubes-audio-daemon`
- configure the Qubes X wrapper through package lifecycle callbacks and a pacman transaction hook
- carry the runtime dependencies and configuration-file metadata required by Arch templates

## Motivation

This implements the Arch Linux packaging requested in [QubesOS/qubes-issues#9231](https://github.com/QubesOS/qubes-issues/issues/9231#issuecomment-5207034775), allowing the GUI and audio daemons to be built and installed through the standard Qubes Builder workflow for Arch-based templates.

Closes QubesOS/qubes-issues#9231

## AI assistance

AI tools assisted with implementation research, packaging metadata, and build diagnostics. The resulting changes were reviewed by the commit author, who retains responsibility for them.
